### PR TITLE
Allow timings to be saved with a null profiler

### DIFF
--- a/MvcMiniProfiler/Storage/SqlServerStorage.cs
+++ b/MvcMiniProfiler/Storage/SqlServerStorage.cs
@@ -133,7 +133,7 @@ values      (@Id,
             conn.Execute(sql, new
             {
                 Id = t.Id,
-                MiniProfilerId = t.Profiler.Id,
+                MiniProfilerId = profiler.Id,
                 ParentTimingId = t.IsRoot ? (Guid?)null : t.ParentTiming.Id,
                 Name = t.Name.Truncate(200),
                 Depth = t.Depth,


### PR DESCRIPTION
Signed-off-by: Mark Young mark@developer.geek.nz

Hi Sam,

Will get in touch with you tomorrow about a whole bunch of playing I've done with this awesome library.  This is just a bug fix which allows for timings to be saved after having been serialised (WCF or similar).  Currently SqlTimings were fine but standard ones weren't.

Will send more mail your way in a tick.
