### PR TITLE
Altering z-index of the ".profiler-results" so that it's always on top. I

### DIFF
--- a/MvcMiniProfiler/UI/Includes.less
+++ b/MvcMiniProfiler/UI/Includes.less
@@ -207,6 +207,7 @@
 
 // ajaxed-in results will be appended to this
 .profiler-results {
+    z-index: 9999;
     position:fixed;
     top:0px;
 


### PR DESCRIPTION
Altering z-index of the ".profiler-results" so that it's always on top. Issues with sites that have other elements with a z-index of anything other than 0.

I'm currently designing a site that has a header span the top of the page with a z-index: 2; which prevents the mini-profiler from being viewed
