### PR TITLE
added minimize and clear controls to UI

### DIFF
--- a/MvcMiniProfiler/MiniProfiler.Settings.cs
+++ b/MvcMiniProfiler/MiniProfiler.Settings.cs
@@ -154,6 +154,13 @@ namespace MvcMiniProfiler
             public static RenderPosition PopupRenderPosition { get; set; }
 
             /// <summary>
+            /// Determines if min-max, clear, etc are rendered; defaults to false.
+            /// For a per-page override you can use .RenderIncludes(showControls: true/false)
+            /// </summary>
+            [DefaultValue(false)]
+            public static bool ShowControls { get; set; }
+
+            /// <summary>
             /// By default, SqlTimings will grab a stack trace to help locate where queries are being executed.
             /// When this setting is true, no stack trace will be collected, possibly improving profiler performance.
             /// </summary>

--- a/MvcMiniProfiler/MiniProfiler.cs
+++ b/MvcMiniProfiler/MiniProfiler.cs
@@ -447,9 +447,9 @@ namespace MvcMiniProfiler
         /// <param name="showTimeWithChildren">Whether to show time the time with children column by default (defaults to false)</param>
         /// <param name="maxTracesToShow">The maximum number of trace popups to show before removing the oldest (defaults to 15)</param>
         /// <returns>Script and link elements normally; an empty string when there is no active profiling session.</returns>
-        public static IHtmlString RenderIncludes(RenderPosition? position = null, bool? showTrivial = null, bool? showTimeWithChildren = null, int? maxTracesToShow = null)
+        public static IHtmlString RenderIncludes(RenderPosition? position = null, bool? showTrivial = null, bool? showTimeWithChildren = null, int? maxTracesToShow = null, bool? showControls = null)
         {
-            return UI.MiniProfilerHandler.RenderIncludes(Current, position, showTrivial, showTimeWithChildren, maxTracesToShow);
+            return UI.MiniProfilerHandler.RenderIncludes(Current, position, showTrivial, showTimeWithChildren, maxTracesToShow, showControls);
         }
 
         /// <summary>

--- a/MvcMiniProfiler/UI/Includes.js
+++ b/MvcMiniProfiler/UI/Includes.js
@@ -2,6 +2,7 @@
 
     var options,
         container,
+        controls,
         fetchedIds = [],
         fetchingIds = []  // so we never pull down a profiler twice
         ;
@@ -70,7 +71,7 @@
                         fetchedIds.push(id);
                         buttonShow(json);
                     },
-                    complete: function() {
+                    complete: function () {
                         fetchingIds.splice(idx, 1);
                     }
                 });
@@ -83,8 +84,14 @@
     };
 
     var buttonShow = function (json) {
-        var result = renderTemplate(json).appendTo(container),
-            button = result.find('.profiler-button'),
+        var result = renderTemplate(json);
+
+        if (controls)
+            result.insertBefore(controls);
+        else
+            result.appendTo(container);
+
+        var button = result.find('.profiler-button'),
             popup = result.find('.profiler-popup');
 
         // button will appear in corner with the total profiling duration - click to show details
@@ -214,16 +221,17 @@
                 highlightHex = '#FFFFBB',
                 highlightRgb = getRGB(highlightHex),
                 originalRgb = getRGB(cell.css('background-color')),
-                getColorDiff = function(fx, i) {
+                getColorDiff = function (fx, i) {
                     // adapted from John Resig's color plugin: http://plugins.jquery.com/project/color
                     return Math.max(Math.min(parseInt((fx.pos * (originalRgb[i] - highlightRgb[i])) + highlightRgb[i]), 255), 0);
                 };
-            
+
             // we need to animate some other property to piggy-back on the step function, so I choose you, opacity!
             cell.css({ 'opacity': 1, 'background-color': highlightHex })
-                .animate({ 'opacity': 1 }, { duration: 2000, step: function(now, fx) {
+                .animate({ 'opacity': 1 }, { duration: 2000, step: function (now, fx) {
                     fx.elem.style['backgroundColor'] = "rgb(" + [getColorDiff(fx, 0), getColorDiff(fx, 1), getColorDiff(fx, 2)].join(",") + ")";
-                }});
+                }
+                });
         });
     };
 
@@ -231,7 +239,7 @@
     // By Blair Mitchelmore
     // http://jquery.offput.ca/highlightFade/
     // Parse strings looking for color tuples [255,255,255]
-    var getRGB = function(color) {
+    var getRGB = function (color) {
         var result;
 
         // Check if we're already dealing with an array of colors
@@ -312,12 +320,43 @@
         });
     };
 
+    var initControls = function (container) {
+        if (options.showControls) {
+            controls = $('<div class="profiler-controls"><span class="profiler-min-max">m</span><span class="profiler-clear">c</span></div>').appendTo(container);
+
+            $('.profiler-controls .profiler-min-max').click(function () {
+                container.toggleClass('profiler-min');
+            });
+
+            container.hover(function () {
+                if ($(this).hasClass('profiler-min')) {
+                    $(this).find('.profiler-min-max').show();
+                }
+            },
+            function () {
+                if ($(this).hasClass('profiler-min')) {
+                    $(this).find('.profiler-min-max').hide();
+                }
+            });
+
+            $('.profiler-controls .profiler-clear').click(function () {
+                container.find('.profiler-result').remove();
+            });
+        }
+        else {
+            container.addClass('profiler-no-controls');
+        }
+    };
+
     var initPopupView = function () {
         // all fetched profilings will go in here
         container = $('<div class="profiler-results"/>').appendTo('body');
 
         // MiniProfiler.RenderIncludes() sets which corner to render in - default is upper left
         container.addClass(options.renderPosition);
+
+        //initialize the controls
+        initControls(container);
 
         // we'll render results json via a jquery.tmpl - after we get the templates, we'll fetch the initial json to populate it
         fetchTemplates(function () {
@@ -340,18 +379,18 @@
 
         // fetch results after ASP Ajax calls
         if (typeof (Sys) != "undefined") {
-        // Get the instance of PageRequestManager.
-        var PageRequestManager = Sys.WebForms.PageRequestManager.getInstance();
+            // Get the instance of PageRequestManager.
+            var PageRequestManager = Sys.WebForms.PageRequestManager.getInstance();
 
-        PageRequestManager.add_endRequest(function (sender, args) {
-            if (args) {
-                var stringIds = args.get_response().getResponseHeader('X-MiniProfiler-Ids');
-                if (stringIds) {
-                    var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
-                    fetchResults(ids);
+            PageRequestManager.add_endRequest(function (sender, args) {
+                if (args) {
+                    var stringIds = args.get_response().getResponseHeader('X-MiniProfiler-Ids');
+                    if (stringIds) {
+                        var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
+                        fetchResults(ids);
+                    }
                 }
-            }
-        });
+            });
         }
 
         // some elements want to be hidden on certain doc events

--- a/MvcMiniProfiler/UI/Includes.less
+++ b/MvcMiniProfiler/UI/Includes.less
@@ -215,13 +215,13 @@
     &.left {
         left:0px;
 
-        .profiler-result:last-child .profiler-button {
+        &.profiler-no-controls .profiler-result:last-child .profiler-button, .profiler-controls {
             -webkit-border-bottom-right-radius: @radius;
             -moz-border-radius-bottomright: @radius;
             border-bottom-right-radius: @radius;
         }
 
-        .profiler-button {
+        .profiler-button, .profiler-controls {
             border-right: 1px solid @buttonBorderColor;
         }
     }
@@ -229,18 +229,18 @@
     &.right {
         right:0px;
 
-        .profiler-result:last-child .profiler-button {
+        &.profiler-no-controls .profiler-result:last-child .profiler-button, .profiler-controls {
             -webkit-border-bottom-left-radius: @radius;
             -moz-border-radius-bottomleft: @radius;
             border-bottom-left-radius: @radius;
         }
 
-        .profiler-button {
+        .profiler-button, .profiler-controls {
             border-left: 1px solid @buttonBorderColor;
         }
     }
 
-    .profiler-button {
+    .profiler-button, .profiler-controls {
         display:none;
         z-index:@zindex;
         border-bottom: 1px solid @buttonBorderColor;
@@ -262,6 +262,25 @@
             }
         }
     }
+
+	.profiler-controls {
+		display: block;
+		font-size:12px;
+		font-family: @codeFonts;
+		cursor:default;
+		text-align: center;
+
+		span {
+			border-right: 1px solid @mutedColor;
+			padding-right: 5px;
+			margin-right: 5px;
+			cursor:pointer;
+		}
+
+		span:last-child {
+			border-right: none;
+		}		
+	}
 
     .profiler-popup {
         display:none;
@@ -323,6 +342,20 @@
             font-size:17px;
         }
     }
+
+	&.profiler-min .profiler-result {
+		display: none;
+	}
+
+	&.profiler-min .profiler-controls span {
+		display: none;
+	}
+
+	&.profiler-min .profiler-controls .profiler-min-max {
+		border-right: none;
+		padding: 0px;
+		margin: 0px;
+	}
 }
 
 // popup results' queries will be displayed in front of this

--- a/MvcMiniProfiler/UI/MiniProfilerHandler.cs
+++ b/MvcMiniProfiler/UI/MiniProfilerHandler.cs
@@ -14,7 +14,7 @@ namespace MvcMiniProfiler.UI
     /// </summary>
     public class MiniProfilerHandler : IRouteHandler, IHttpHandler
     {
-        internal static HtmlString RenderIncludes(MiniProfiler profiler, RenderPosition? position = null, bool? showTrivial = null, bool? showTimeWithChildren = null, int? maxTracesToShow = null)
+        internal static HtmlString RenderIncludes(MiniProfiler profiler, RenderPosition? position = null, bool? showTrivial = null, bool? showTimeWithChildren = null, int? maxTracesToShow = null, bool? showControls = null)
         {
             const string format =
 @"<link rel=""stylesheet"" type=""text/css"" href=""{path}mini-profiler-includes.css?v={version}"">
@@ -32,7 +32,8 @@ namespace MvcMiniProfiler.UI
             renderPosition: '{position}',
             showTrivial: {showTrivial},
             showChildrenTime: {showChildren},
-            maxTracesToShow: {maxTracesToShow}
+            maxTracesToShow: {maxTracesToShow},
+            showControls: {showControls}
         }});
     }});
 </script>";
@@ -54,7 +55,8 @@ namespace MvcMiniProfiler.UI
                     position = (position ?? MiniProfiler.Settings.PopupRenderPosition).ToString().ToLower(),
                     showTrivial = showTrivial ?? MiniProfiler.Settings.PopupShowTrivial ? "true" : "false",
                     showChildren = showTimeWithChildren ?? MiniProfiler.Settings.PopupShowTimeWithChildren ? "true" : "false",
-                    maxTracesToShow = maxTracesToShow ?? MiniProfiler.Settings.PopupMaxTracesToShow
+                    maxTracesToShow = maxTracesToShow ?? MiniProfiler.Settings.PopupMaxTracesToShow,
+                    showControls = showControls ?? MiniProfiler.Settings.ShowControls ? "true" : "false"
                 });
             }
 


### PR DESCRIPTION
This commit adds the ability to minimize and clear the mini-profiler UI.

All controls are shown below the profiler results.

The minimize control is represented by a lower case 'm' and is necessary in some situations where design is non-optimal and mini-profiler is obstructing the view of underlying elements.  When minimize is pressed, all results and controls are hidden and the mini-profiler UI becomes as small as possible. To maximize the UI the user must hover over what remains of the UI and then click the 'm' icon again.

The clear control is represented by a lower case 'c' and is necessary when working on highly AJAX dependent sites.  Sometimes you can have difficulty identifying which profiler result is the one you want to inspect, so clear can be used to remove all existing results.  The user can then perform their interaction and see only the newly loaded results.

Controls are optional and turned off by default, so out of the box mini-profiler works as before.  To enable the controls a user must have a RenderIncludes call similar to the following:

RenderIncludes(showControls: true)
