### PR TITLE
Issue 100 - Added MiniProfilerEF.Initialize_EF42 to workaround EF bug

### DIFF
--- a/MvcMiniProfiler.EntityFramework/EFProfiledDbProviderFactory.cs
+++ b/MvcMiniProfiler.EntityFramework/EFProfiledDbProviderFactory.cs
@@ -20,7 +20,7 @@ namespace MvcMiniProfiler.Data
         /// <summary>
         /// Used for db provider apis internally 
         /// </summary>
-        private EFProfiledDbProviderFactory ()
+        protected EFProfiledDbProviderFactory ()
 	    {
             FieldInfo field = typeof(T).GetField("Instance", BindingFlags.Public | BindingFlags.Static);
             this.tail = (T)field.GetValue(null);

--- a/MvcMiniProfiler.EntityFramework/EFProfiledOdbcProviderFactory.cs
+++ b/MvcMiniProfiler.EntityFramework/EFProfiledOdbcProviderFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Data.SqlClient;
+using System.Data.Odbc;
+
+namespace MvcMiniProfiler.Data
+{
+    /// <summary>
+    /// Specific implementation of EFProfiledDbProviderFactory&lt;OdbcFactory&gt; to enable profiling
+    /// </summary>
+    public class EFProfiledOdbcProviderFactory
+        : EFProfiledDbProviderFactory<OdbcFactory>
+    {
+        private EFProfiledOdbcProviderFactory()
+        { }
+
+        /// <summary>
+        /// Every provider factory must have an Instance public field
+        /// </summary>
+        public static new EFProfiledOdbcProviderFactory Instance = new EFProfiledOdbcProviderFactory();
+
+    }
+}

--- a/MvcMiniProfiler.EntityFramework/EFProfiledOleDbProviderFactory.cs
+++ b/MvcMiniProfiler.EntityFramework/EFProfiledOleDbProviderFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Data.SqlClient;
+using System.Data.OleDb;
+
+namespace MvcMiniProfiler.Data
+{
+    /// <summary>
+    /// Specific implementation of EFProfiledDbProviderFactory&lt;OleDbFactory&gt; to enable profiling
+    /// </summary>
+    public class EFProfiledOleDbProviderFactory
+        : EFProfiledDbProviderFactory<OleDbFactory>
+    {
+        private EFProfiledOleDbProviderFactory()
+        { }
+
+        /// <summary>
+        /// Every provider factory must have an Instance public field
+        /// </summary>
+        public static new EFProfiledOleDbProviderFactory Instance = new EFProfiledOleDbProviderFactory();
+
+    }
+}

--- a/MvcMiniProfiler.EntityFramework/EFProfiledSqlClientDbProviderFactory.cs
+++ b/MvcMiniProfiler.EntityFramework/EFProfiledSqlClientDbProviderFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Data.SqlClient;
+
+namespace MvcMiniProfiler.Data
+{
+    /// <summary>
+    /// Specific implementation of EFProfiledDbProviderFactory&lt;SqlClientFactory&gt; to enable profiling
+    /// </summary>
+    public class EFProfiledSqlClientDbProviderFactory
+        : EFProfiledDbProviderFactory<SqlClientFactory>
+    {
+        private EFProfiledSqlClientDbProviderFactory()
+        { }
+
+        /// <summary>
+        /// Every provider factory must have an Instance public field
+        /// </summary>
+        public static new EFProfiledSqlClientDbProviderFactory Instance = new EFProfiledSqlClientDbProviderFactory();
+
+    }
+}

--- a/MvcMiniProfiler.EntityFramework/MiniProfilerEF.cs
+++ b/MvcMiniProfiler.EntityFramework/MiniProfilerEF.cs
@@ -15,6 +15,22 @@ namespace MvcMiniProfiler
         /// </summary>
         public static void Initialize()
         {
+            InitializeDbProviderFactories(GetProfiledProviderFactoryType);
+        }
+
+        
+        /// <summary>
+        /// Called exactly once, to setup DbProviderFactory interception, so SQL is profiled
+        /// Use this version when using EF 4.1 Update 1, EF 4.2 or later
+        /// See http://weblogs.asp.net/fbouma/archive/2011/07/28/entity-framework-v4-1-update-1-the-kill-the-tool-eco-system-version.aspx?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+FransBouma+%28Frans+Bouma%29
+        /// </summary>
+        public static void Initialize_EF42()
+        {
+            InitializeDbProviderFactories(GetEF42ProfiledProviderFactoryType);
+        }
+
+        private static void InitializeDbProviderFactories(Func<Type, Type> resolveProfilerTypeFunc)
+        {
             try
             {
                 // ensure all the factories are loaded 
@@ -48,18 +64,35 @@ namespace MvcMiniProfiler
                     continue;
                 }
 
-                var profType = typeof(MvcMiniProfiler.Data.EFProfiledDbProviderFactory<>).MakeGenericType(factory.GetType());
-
-
-                DataRow profiled = table.NewRow();
-                profiled["Name"] = row["Name"];
-                profiled["Description"] = row["Description"];
-                profiled["InvariantName"] = row["InvariantName"];
-                profiled["AssemblyQualifiedName"] = profType.AssemblyQualifiedName;
-                table.Rows.Remove(row);
-                table.Rows.Add(profiled);
-
+                var profType = resolveProfilerTypeFunc(factory.GetType());
+                if (profType != null)
+                {
+                    DataRow profiled = table.NewRow();
+                    profiled["Name"] = row["Name"];
+                    profiled["Description"] = row["Description"];
+                    profiled["InvariantName"] = row["InvariantName"];
+                    profiled["AssemblyQualifiedName"] = profType.AssemblyQualifiedName;
+                    table.Rows.Remove(row);
+                    table.Rows.Add(profiled);
+                }
             }
+        }
+
+        private static Type GetProfiledProviderFactoryType(Type factoryType)
+        {
+            return typeof(Data.EFProfiledDbProviderFactory<>).MakeGenericType(factoryType);
+        }
+
+        private static Type GetEF42ProfiledProviderFactoryType(Type factoryType)
+        {
+            if (factoryType == typeof(System.Data.SqlClient.SqlClientFactory))
+                return typeof(Data.EFProfiledSqlClientDbProviderFactory);
+            else if (factoryType == typeof(System.Data.OleDb.OleDbFactory))
+                return typeof(Data.EFProfiledOleDbProviderFactory);
+            else if (factoryType == typeof(System.Data.Odbc.OdbcFactory))
+                return typeof(Data.EFProfiledOdbcProviderFactory);
+
+            return null;
         }
     }
 }

--- a/MvcMiniProfiler.EntityFramework/MvcMiniProfiler.EntityFramework.csproj
+++ b/MvcMiniProfiler.EntityFramework/MvcMiniProfiler.EntityFramework.csproj
@@ -57,6 +57,9 @@
     <Compile Include="EFProfiledDbConnection.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="EFProfiledOdbcProviderFactory.cs" />
+    <Compile Include="EFProfiledOleDbProviderFactory.cs" />
+    <Compile Include="EFProfiledSqlClientDbProviderFactory.cs" />
     <Compile Include="MiniProfilerEF.cs" />
     <Compile Include="ObjectContextUtils.cs" />
     <Compile Include="ProfiledDbConnectionFactory.cs" />


### PR DESCRIPTION
Signed-off-by: Mark Young mark@developer.geek.nz

Fix for Issue #100 - occurs with recent versions of EF4. This adds a new (hopefully temporary method) Initialize_EF42 which supports profiling SqlClient, Odbc, Ole (not SqlCE currently as this required a new reference).
