### PR TITLE
Modifies WcfMiniProfilerDispatchInspector to explicitly use WcfRequestProfileProvider

### DIFF
--- a/MvcMiniProfiler.Wcf/WcfMiniProfilerDispatchInspector.cs
+++ b/MvcMiniProfiler.Wcf/WcfMiniProfilerDispatchInspector.cs
@@ -19,6 +19,7 @@ namespace MvcMiniProfiler.Wcf
                 var requestHeader = request.Headers.GetHeader<MiniProfilerRequestHeader>(headerIndex);
                 if (requestHeader != null)
                 {
+                    MiniProfiler.Settings.ProfilerProvider = new WcfRequestProfilerProvider();
                     MiniProfiler.Start();
                     return requestHeader;
                 }


### PR DESCRIPTION
Modifies `WcfMiniProfilerDispatchInspector` to explicitly set `MiniProfiler.Settings.ProfileProvider` to `WcfRequestProfileProvider` before calling `MiniProfiler.Start()` to avoid using default `WebRequestProfilerProvider`.

I found this is required to get profiling information from WCF services hosted in a standard service host exe, otherwise `MiniProfiler.Current` is null. Changing this doesn't seem to affect the behaviour of the Wcf Sample App.
