### PR TITLE
Update parent HasSqlTimings property when adding external profiler results

### DIFF
--- a/MvcMiniProfiler/MiniProfiler.cs
+++ b/MvcMiniProfiler/MiniProfiler.cs
@@ -485,8 +485,8 @@ namespace MvcMiniProfiler
             if (profiler == null || profiler.Head == null || externalProfiler == null) return;
             profiler.Head.AddChild(externalProfiler.Root);
             
-            profiler.HasSqlTimings = profiler.GetTimingHierarchy().Any(t => t.HasSqlTimings);
-            profiler.HasDuplicateSqlTimings = profiler.GetTimingHierarchy().Any(t => t.HasDuplicateSqlTimings);
+            profiler.HasSqlTimings |= externalProfiler.HasSqlTimings;
+            profiler.HasDuplicateSqlTimings |= externalProfiler.HasDuplicateSqlTimings;
         }
 
         /// <summary>


### PR DESCRIPTION
Modified MvcMiniProfilerExtensions.AddProfileResults to update the parent profiler's HasSqlTimings and HasDuplicateSqlTimings properties to ensure property values are accurate.

Currently if external profiler results are added that have Sql Timings, but the parent profiler doesn't, the parent will not be updated to reflect that some of its children have timings. This causes JS errors when the SQL link is clicked on to display the queries, and the results display stops functioning correctly.
