### PR TITLE
System.Data.OracleClient.OracleParameter.Size may throw exception

### DIFF
--- a/MvcMiniProfiler/SqlTiming.cs
+++ b/MvcMiniProfiler/SqlTiming.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 using System.Web.Script.Serialization;
 
 using MvcMiniProfiler.Helpers;
+using System.Data.SqlTypes;
 
 namespace MvcMiniProfiler
 {
@@ -221,12 +222,25 @@ namespace MvcMiniProfiler
                         Name = dbParameter.ParameterName.Trim(),
                         Value = formattedParameterValue,
                         DbType = dbParameter.DbType.ToString(),
-                        Size = dbParameter.Size
+                        Size = GetParameterSize(dbParameter)
                     });
                 }
             }
 
             return result;
+        }
+
+        private static int GetParameterSize(DbParameter dbParameter)
+        {
+            if (dbParameter.Value is INullable)
+            {
+                var nullable = ((INullable)dbParameter.Value);
+                if (nullable.IsNull)
+                {
+                    return 0;
+                }
+            }
+            return dbParameter.Size;
         }
 
         private static string GetFormattedParameterValue(DbParameter dbParameter)


### PR DESCRIPTION
When using ProfiledDbConnection, the System.Data.OracleClient.OracleParameter.Size may throw an InvalidOperationException if the OracleParameter.Value is OracleBinary.Null or OracleString.Null and the Size property on the parameter is not explicitly set.

The Microsoft SqlParameter will return 0 if the value is of SqlString, SqlChars, SqlBinary, etc. See SqlParameter.ValueSize in Reflector.

However, The OracleParameter will just let the exception be thrown instead of returning zero. This causes a problem in the SqlTiming class which attempts to get the size of every parameter.

This actually appears to be a bug in the OracleParameter class, as it does check for null, but after it will actually throw the exception.

The fix is to check if the parameter value is INullable, if it is, and IsNull is true, return zero (which is consistent with how SqlString, SqlChars, and SqlBinary work). This will alleviate the problem for those using the Microsoft .NET Oracle provider without any explicit dependencies on the System.Data.OracleClient.
