### PR TITLE
Prevent C# code opening in VS Designer.

### DIFF
--- a/StackExchange.Profiling/Data/ProfiledDbCommand.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbCommand.cs
@@ -9,6 +9,7 @@ using System.Reflection.Emit;
 
 namespace StackExchange.Profiling.Data
 {
+    [System.ComponentModel.DesignerCategory("")]
     public class ProfiledDbCommand : DbCommand, ICloneable
     {
         protected DbCommand _cmd;

--- a/StackExchange.Profiling/Data/ProfiledDbConnection.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbConnection.cs
@@ -8,6 +8,7 @@ namespace StackExchange.Profiling.Data
     /// <summary>
     /// Wraps a database connection, allowing sql execution timings to be collected when a <see cref="MiniProfiler"/> session is started.
     /// </summary>
+    [System.ComponentModel.DesignerCategory("")]
     public class ProfiledDbConnection : DbConnection, ICloneable
     {
         /// <summary>

--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -69,12 +69,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Data\Link.cs" />
-    <Compile Include="Data\ProfiledDbCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Data\ProfiledDbConnection.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="Data\ProfiledDbCommand.cs" />
+    <Compile Include="Data\ProfiledDbConnection.cs" />
     <Compile Include="Data\ProfiledDbDataReader.cs" />
     <Compile Include="Data\ProfiledDbTransaction.cs" />
     <Compile Include="Helpers\IStopwatch.cs" />


### PR DESCRIPTION
Adding the [DesignerCategory("")] attribute causes Visual Studio to
open these files in the C# code editor, rather than the designer,
when they are double-clicked in Solution Explorer.
