### PR TITLE
Dispose SHA256 object after use.

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.Settings.cs
+++ b/StackExchange.Profiling/MiniProfiler.Settings.cs
@@ -36,8 +36,8 @@ namespace StackExchange.Profiling
 
                 // sha256 is FIPS BABY - FIPS 
                 byte[] contents = System.IO.File.ReadAllBytes(typeof(Settings).Assembly.Location);
-                var sha256 = System.Security.Cryptography.SHA256.Create();
-                Version = System.Convert.ToBase64String(sha256.ComputeHash(contents));
+                using (var sha256 = System.Security.Cryptography.SHA256.Create())
+                    Version = System.Convert.ToBase64String(sha256.ComputeHash(contents));
 
                 typesToExclude = new HashSet<string>
                 {


### PR DESCRIPTION
Although this object is only created once per AppDomain (in a static constructor), disposing it is still the right thing to do. (Unless it's `SHA256Managed`, it will be holding a CSP or CNG native object that can be cleaned up immediately without relying on the finalizer.)
