### PR TITLE
Fix for Google code issue #124

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.cs
+++ b/StackExchange.Profiling/MiniProfiler.cs
@@ -491,6 +491,8 @@ namespace StackExchange.Profiling
         {
             if (profiler == null || profiler.Head == null || externalProfiler == null) return;
             profiler.Head.AddChild(externalProfiler.Root);
+            profiler.HasSqlTimings |= externalProfiler.HasSqlTimings;
+            profiler.HasDuplicateSqlTimings |= externalProfiler.HasDuplicateSqlTimings;
         }
 
         /// <summary>


### PR DESCRIPTION
http://code.google.com/p/mvc-mini-profiler/issues/detail?id=124

It may not be the optimal solution (because we will reevaluate the property each time an external profile is added) but it works.

Maybe these properties should be (re-)evaluated before serialisation to Json ?
