### PR TITLE
MiniProfiler.EntityFramework .nuspec fix for binaries

### DIFF
--- a/MiniProfiler.EF.nuspec
+++ b/MiniProfiler.EF.nuspec
@@ -15,6 +15,6 @@
     <language>en-US</language>
   </metadata>
   <files>
-    <file src="StackExchange.Profiling.EntityFramework\bin\Release\StackExchange.Profiling.EntityFramework.*" target="lib/net40" />
+    <file src="StackExchange.Profiling.EntityFramework\bin\Release\MiniProfiler.EntityFramework.*" target="lib/net40" />
   </files>
 </package>


### PR DESCRIPTION
The .nuspec file for MiniProfiler.EntityFramework refers to “StackExchange.Profiling.EntityFramework.*”, but the assembly name in the .csproj is “MiniProfiler.EntityFramework”; this patch changes the former to use the latter, which seems to be in line with the name of the main MiniProfiler.dll.
