### PR TITLE
Fix for Google Code Issue 141

### DIFF
--- a/StackExchange.Profiling/UI/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/UI/MiniProfilerHandler.cs
@@ -167,7 +167,7 @@ namespace StackExchange.Profiling.UI
             string output;
             string path = context.Request.AppRelativeCurrentExecutionFilePath;
 
-            switch (Path.GetFileNameWithoutExtension(path))
+            switch (Path.GetFileNameWithoutExtension(path).ToLowerInvariant())
             {
                 case "jquery.1.7.1":
                 case "jquery.tmpl":


### PR DESCRIPTION
Fix for Google Code Issue 141 where resources are requested that do not match the case in the switch statement. (http://code.google.com/p/mvc-mini-profiler/issues/detail?id=141)

To prevent future issues, it now calls ToLowerInvariant() on requested resources.
