### PR TITLE
Bugfix: InlineFormatter parameter replacement bug

### DIFF
--- a/StackExchange.Profiling/SqlFormatters/InlineFormatter.cs
+++ b/StackExchange.Profiling/SqlFormatters/InlineFormatter.cs
@@ -38,7 +38,7 @@ namespace StackExchange.Profiling.SqlFormatters
                 // If the parameter doesn't have a prefix (@,:,etc), append one
                 var name = _paramPrefixes.IsMatch(p.Name) ? p.Name : Regex.Match(sql, "([@:?])" + p.Name).Value;
                 var value = GetParameterValue(p);
-                sql = Regex.Replace(sql, name, m => value, RegexOptions.IgnoreCase);
+                sql = Regex.Replace(sql, "(" + name + ")([^0-9]|$)", m => value + m.Groups[2], RegexOptions.IgnoreCase);
             }
 
             return sql;


### PR DESCRIPTION
I ran into this issue with the InlineFormatter:

Scenario:
- Sql contains many parameters caused by "where x IN ..." implementation, like "where myid in (@myid1, @myid2, ..., @myid11, @Myid12)".
- Now the replacement algorithm will replace both @myid1, (@myid1)1 and (@myid1)2 with the value of @myid1
- Effect seen: Garbled sql in profiler output, or even worse, out-of-memory exceptions.

Fix modifies replacement regex to only replace @myid1 and not @myid1something.
