### PR TITLE
Don't compare relative to absolute path

### DIFF
--- a/StackExchange.Profiling/WebRequestProfilerProvider.cs
+++ b/StackExchange.Profiling/WebRequestProfilerProvider.cs
@@ -41,7 +41,7 @@ namespace StackExchange.Profiling
                     return null;
             }
 
-            if (path.StartsWith(VirtualPathUtility.ToAbsolute(MiniProfiler.Settings.RouteBasePath).ToUpperInvariant()))
+            if (context.Request.Path.StartsWith(VirtualPathUtility.ToAbsolute(MiniProfiler.Settings.RouteBasePath), StringComparison.InvariantCultureIgnoreCase))
             {
                 return null;
             }


### PR DESCRIPTION
When the website root is not the domain root (e.g. www.example.com/myapp/) all requests to `MiniProfilerHandler.ProcessRequest` are profiled too. This quite annoying, because on every page request one more request to `mini-profiler-resorces/results` is added (-> i.e. some kind of infinite loop).

The reason for this behavior is a comparison of an app-relative path to an absolute path in `WebRequestProfilerProvider`.

`path` is made relative by removing the leading `~` in [line 35](https://github.com/SamSaffron/MiniProfiler/blob/master/StackExchange.Profiling/WebRequestProfilerProvider.cs#L35), but `MiniProfiler.Settings.RouteBasePath` is converted to an absolute path ([line 44](https://github.com/SamSaffron/MiniProfiler/blob/master/StackExchange.Profiling/WebRequestProfilerProvider.cs#L44)).

Comparing only absolute paths fixes the issue:

```
context.Request.Path.StartsWith(VirtualPathUtility.ToAbsolute(MiniProfiler.Settings.RouteBasePath), StringComparison.InvariantCultureIgnoreCase)
```
