### PR TITLE
Fix for bug #39

### DIFF
--- a/StackExchange.Profiling/Storage/SqlServerStorage.cs
+++ b/StackExchange.Profiling/Storage/SqlServerStorage.cs
@@ -345,6 +345,7 @@ values      (@MiniProfilerId,
                     ClientTimings clientTimings = null;
                     if (clientTimingList.Count > 0)
                     {
+                        clientTimings = new ClientTimings();
                         clientTimings.Timings = clientTimingList;
                     }
                     MapTimings(result, timings, sqlTimings, sqlParameters, clientTimings);


### PR DESCRIPTION
This just adds a `clientTimings = new ClientTimings();` to `LoadInBatch()`. It should take care of bug #39 about a null reference when loading client timings.
