### PR TITLE
Make the WrappedTransaction property of ProfiledDbTransaction be public

### DIFF
--- a/StackExchange.Profiling/Data/ProfiledDbTransaction.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbTransaction.cs
@@ -24,7 +24,7 @@ namespace StackExchange.Profiling.Data
             get { return _conn; }
         }
 
-        internal DbTransaction WrappedTransaction
+        public DbTransaction WrappedTransaction
         {
             get { return _trans; }
         }


### PR DESCRIPTION
In some use cases (eg. Sql Server Bulk insert), a reference of the real SqlTransaction is needed to achieve a transacted operation.

Making this readonly property public should have minor impact on the code and it is similar to the WrappedConnection of the ProfiledDbConnection class.
