### PR TITLE
A remedy for "headers blew up" exceptions.

### DIFF
--- a/StackExchange.Profiling/WebRequestProfilerProvider.cs
+++ b/StackExchange.Profiling/WebRequestProfilerProvider.cs
@@ -107,7 +107,10 @@ namespace StackExchange.Profiling
                 }
 
                 // allow profiling of ajax requests
-                response.AppendHeader("X-MiniProfiler-Ids", arrayOfIds.ToJson());
+                if (arrayOfIds != null && arrayOfIds.Count > 0)
+                {
+                    response.AppendHeader("X-MiniProfiler-Ids", arrayOfIds.ToJson());
+                }
             }
             catch { } // headers blew up
         }


### PR DESCRIPTION
Hi Sam, thanks for your work on the MiniProfiler.

The story is that I debug our web site with "brake on thrown exceptions" and it gets pretty painful, since MiniProfiler is throwing up an HttpException on every page.

We are using a bit dated version of the profiler, so it's possible that you've already fixed this, but if not - would you consider to avoid sending an empty array of IDs in the headers? This really helps to get rid of those nasty "Server cannot append header after HTTP headers have been sent." exceptions.
- D.
