### PR TITLE
Issue with creating profiled EF connection

### DIFF
--- a/StackExchange.Profiling.EntityFramework/ObjectContextUtils.cs
+++ b/StackExchange.Profiling.EntityFramework/ObjectContextUtils.cs
@@ -65,8 +65,14 @@ namespace StackExchange.Profiling.Data
             object configName;
             if (builder.TryGetValue("name", out configName))
             {
-                var configEntry = WebConfigurationManager.ConnectionStrings[configName.ToString()];
-                builder = new EntityConnectionStringBuilder(configEntry.ConnectionString);
+                //  As of EF 4.1, it appears that TryGetValue("name") returns a blank
+                //  string if there is no name key.  Added test to confirm that 
+                //  something has been returned.
+                if (!String.IsNullOrEmpty(configName.ToString()))
+                {
+                    var configEntry = WebConfigurationManager.ConnectionStrings[configName.ToString()];
+                    builder = new EntityConnectionStringBuilder(configEntry.ConnectionString);
+                }
             }
 
             // Find the proper factory for the underlying connection.


### PR DESCRIPTION
When updating to MiniProfiler (goodbye MvcMiniProfiler), I ran into an issue with creating a EFProfiledDbConnection.  

I tracked the issue down to the GetStoreConnection() method in ObjectContextUtils.  builder.TryGetValue("name", ...)  returns an empty string, even where there is no name key in the connection string.  Added a test to insure string is not empty.
