### PR TITLE
allow horizontal scrolling when necessary

### DIFF
--- a/StackExchange.Profiling/UI/includes.less
+++ b/StackExchange.Profiling/UI/includes.less
@@ -359,7 +359,7 @@
         z-index:@zindex + 3;
         position:absolute;
         overflow-y:auto;
-        overflow-x:hidden;
+        overflow-x:auto;
         background-color:#fff;
 
         th {


### PR DESCRIPTION
We have very long URLs so whenever the profiler information pops up it is off to the right and can't be seen unless horizontal scrolling is allowed .
