### PR TITLE
Manage custom templates

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.Settings.cs
+++ b/StackExchange.Profiling/MiniProfiler.Settings.cs
@@ -46,10 +46,31 @@ namespace StackExchange.Profiling
 
                 try
                 {
-                    // sha256 is FIPS BABY - FIPS 
-                    byte[] contents = System.IO.File.ReadAllBytes(location);
+                    List<string> files = new List<string>();
+                    files.Add(location);
+
+                    string customUITemplatesPath = HttpContext.Current.Server.MapPath(MiniProfiler.Settings.CustomUITemplates);
+
+                    if (System.IO.Directory.Exists(customUITemplatesPath))
+                    {
+                        files.AddRange(System.IO.Directory.EnumerateFiles(customUITemplatesPath));
+                    }
+
                     using (var sha256 = System.Security.Cryptography.SHA256.Create())
-                        Version = System.Convert.ToBase64String(sha256.ComputeHash(contents));
+                    {
+                        byte[] hash = new byte[sha256.HashSize / 8];
+                        foreach (string file in files)
+                        {
+                            // sha256 is FIPS BABY - FIPS 
+                            byte[] contents = System.IO.File.ReadAllBytes(file);
+                            byte[] hashfile = sha256.ComputeHash(contents);
+                            for (int i = 0; i < (sha256.HashSize / 8); i++)
+                            {
+                                hash[i] = (byte)(hashfile[i] ^ hash[i]);
+                            }
+                        }
+                        Version = System.Convert.ToBase64String(hash);
+                    }
                 }
                 catch
                 {
@@ -223,6 +244,15 @@ namespace StackExchange.Profiling
             /// </summary>
             [DefaultValue("~/mini-profiler-resources")]
             public static string RouteBasePath { get; set; }
+
+            /// <summary>
+            /// The path where custom ui elements are stored.
+            /// If the custom file doesn't exist, the standard resource is used.
+            /// This setting should be in APP RELATIVE FORM, e.g. "~/App_Data/MiniProfilerUI"
+            /// </summary>
+            /// <remarks>A web server restart is required to reload new files.</remarks>
+            [DefaultValue("~/App_Data/MiniProfilerUI")]
+            public static string CustomUITemplates { get; set; }
 
             /// <summary>
             /// Maximum payload size for json responses in bytes defaults to 2097152 characters, which is equivalent to 4 MB of Unicode string data.

--- a/StackExchange.Profiling/UI/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/UI/MiniProfilerHandler.cs
@@ -174,7 +174,17 @@ namespace StackExchange.Profiling.UI
                     profiler.DurationMilliseconds,
                     profiler.DurationMillisecondsInSql,
                     profiler.ClientTimings,
-                    profiler.Started
+                    profiler.Started,
+                    profiler.ExecutedNonQueries,
+                    profiler.ExecutedReaders,
+                    profiler.ExecutedScalars,
+                    profiler.HasAllTrivialTimings,
+                    profiler.HasDuplicateSqlTimings,
+                    profiler.HasSqlTimings,
+                    profiler.HasTrivialTimings,
+                    profiler.HasUserViewed,
+                    profiler.MachineName,
+                    profiler.User
                 };
             }
             
@@ -368,12 +378,21 @@ namespace StackExchange.Profiling.UI
 
             if (!_ResourceCache.TryGetValue(filename, out result))
             {
-                using (var stream = typeof(MiniProfilerHandler).Assembly.GetManifestResourceStream("StackExchange.Profiling.UI." + filename))
-                using (var reader = new StreamReader(stream))
-                {
-                    result = reader.ReadToEnd();
-                }
+                string customTemplatesPath = HttpContext.Current.Server.MapPath(MiniProfiler.Settings.CustomUITemplates);
+                string customTemplateFile = System.IO.Path.Combine(customTemplatesPath, filename);
 
+                if (System.IO.File.Exists(customTemplateFile))
+                {
+                    result = File.ReadAllText(customTemplateFile);
+                }
+                else
+                {
+                    using (var stream = typeof(MiniProfilerHandler).Assembly.GetManifestResourceStream("StackExchange.Profiling.UI." + filename))
+                    using (var reader = new StreamReader(stream))
+                    {
+                        result = reader.ReadToEnd();
+                    }
+                }
                 _ResourceCache[filename] = result;
             }
 


### PR DESCRIPTION
I added the code to offer the capability to change the UI files (js, tmpl, html) without a recompilation.

A new settings has appeared:
 CustomUITemplates (default value: ~/App_Data/MiniProfilerUI)

If you put a custom file in this directory, this one will be use instead of the standard resource (otherwise the standard stored in the assembly will be use). For optimization, the file contents are cached on the memory of the server and on the client cache.

I changed the calculation of the Version, the custom file contents are used to generate the version with the assembly.

I hope this pull request will be merge with the main version quickly.

Valentin
