### PR TITLE
AJAX request support for ExtJS

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -475,6 +475,18 @@ var MiniProfiler = (function ($) {
             })();
         }
 
+        // also fetch results after ExtJS requests, in case it is being used
+        if (typeof (Ext) != 'undefined' && typeof (Ext.Ajax) != 'undefined' && typeof (Ext.Ajax.on) != 'undefined') {
+            // Ext.Ajax is a singleton, so we just have to attach to its 'requestcomplete' event
+            Ext.Ajax.on('requestcomplete', function(e, xhr, settings) {
+                var stringIds = xhr.getResponseHeader('X-MiniProfiler-Ids');
+                if (stringIds) {
+                    var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
+                    fetchResults(ids);
+                }
+            });
+        }
+
         // some elements want to be hidden on certain doc events
         bindDocumentEvents();
     };


### PR DESCRIPTION
I started trying to use MiniProfiler with our web app just recently, and it's great! However, our group uses ExtJS for client-side development, so most of our AJAX requests use ExtJS instead of jQuery or ASP.NET Ajax. All it took was a small hook in `includes.js` to get the results after the completion of a request. So, here's the modification, in case you'd like to include it in the project.

Also, I'd like to say, thank you very much for building such a great tool, and especially for making it open!
