### PR TITLE
Expose underlying DataAdapter

### DIFF
--- a/StackExchange.Profiling/Data/ProfiledDbDataAdapter.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbDataAdapter.cs
@@ -23,6 +23,14 @@ namespace StackExchange.Profiling.Data
         private IDbCommand _deleteCommand;
 
         /// <summary>
+        /// Exposes the underlying adapter.  Useful for when APIs can't handle the wrapped adapter (e.g. CommandBuilder).
+        /// </summary>
+        public IDbDataAdapter InternalAdapter
+        {
+            get { return _adapter; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ProfiledDataAdapter"/> class.
         /// </summary>
         /// <param name="wrappedAdapter">The wrapped adapter.</param>


### PR DESCRIPTION
useful for cases when APIs won't accept the wrapped adapter.
