### PR TITLE
Made the useExistingJQuery option configurable.

### DIFF
--- a/Ruby/lib/mini_profiler/config.rb
+++ b/Ruby/lib/mini_profiler/config.rb
@@ -14,7 +14,7 @@ module Rack
 
     attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
         :backtrace_remove, :backtrace_filter, :skip_schema_queries, 
-        :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode
+        :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode, :use_existing_jquery
       
       def self.default
         new.instance_eval {
@@ -30,6 +30,7 @@ module Rack
           @storage = MiniProfiler::MemoryStore
           @user_provider = Proc.new{|env| Rack::Request.new(env).ip}
           @authorization_mode = :allow_all
+          @use_existing_jquery = false
           self
         }
       end

--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -380,7 +380,7 @@ module Rack
 			showControls = false
 			currentId = current.page_struct["Id"]
 			authorized = true
-      useExistingjQuery = false
+			useExistingjQuery = @config.use_existing_jquery
 			# TODO : cache this snippet 
 			script = IO.read(::File.expand_path('../html/profile_handler.js', ::File.dirname(__FILE__)))
 			# replace the variables


### PR DESCRIPTION
We already include jquery on our site so we don't want to have to pull it down a second time.  This can lead to unpredictable behavior.  It appeared that the option to use an existing jquery was baked into the javascript template, but not exposed via Ruby.  This commit adds a ruby config option.
