### PR TITLE
Ruby - Fixed migration failure if tmp directory doesn't exist.

### DIFF
--- a/Ruby/lib/mini_profiler_rails/railtie.rb
+++ b/Ruby/lib/mini_profiler_rails/railtie.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module MiniProfilerRails
 
   class Railtie < ::Rails::Railtie
@@ -22,7 +24,7 @@ module MiniProfilerRails
 
       # The file store is just so much less flaky
       tmp = Rails.root.to_s + "/tmp/miniprofiler"
-      Dir::mkdir(tmp) unless File.exists?(tmp)
+      FileUtils.mkdir_p(tmp) unless File.exists?(tmp)
 
       c.storage_options = {:path => tmp}
       c.storage = Rack::MiniProfiler::FileStore


### PR DESCRIPTION
Creation of the miniprofiler directory fails during migration if the tmp directory doesn't exist. 

Also _high-five_ for bringing miniprofiler to ruby!
