### PR TITLE
Remove release date from gemspec

### DIFF
--- a/Ruby/rack-mini-profiler.gemspec
+++ b/Ruby/rack-mini-profiler.gemspec
@@ -3,7 +3,6 @@ Gem::Specification.new do |s|
 	s.version = "0.1.7"
 	s.summary = "Profiles loading speed for rack applications."
 	s.authors = ["Aleks Totic","Sam Saffron", "Robin Ward"]
-	s.date = "2012-04-02"
 	s.description = "Page loading speed displayed on every page. Optimize while you develop, performance is a feature."
 	s.email = "sam.saffron@gmail.com"
 	s.homepage = "http://miniprofiler.com"
@@ -14,9 +13,9 @@ Gem::Specification.new do |s|
 		"README.md",
     "CHANGELOG"
 	]
-	s.add_runtime_dependency 'rack', '>= 1.1.3' 
+	s.add_runtime_dependency 'rack', '>= 1.1.3'
   if RUBY_VERSION < "1.9"
-    s.add_runtime_dependency 'json', '>= 1.6' 
+    s.add_runtime_dependency 'json', '>= 1.6'
   end
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
So far rubygems is displaying all gem releases to have the same hard-coded release date of April 02, 2012. This confuses other developers and makes it difficult to figure when a version was actually released

See rubygems.org/gems/rack-mini-profiler and https://rubygems.org/gems/rack-mini-profiler/versions

By not setting it, when you release the gem, it should use the current date
