### PR TITLE
Make sure jQuery's been loaded before skipping loading it

### DIFF
--- a/Ruby/Rakefile
+++ b/Ruby/Rakefile
@@ -17,7 +17,7 @@ task :build => :compile_less do
 end
 
 desc "compile less"
-task :compile_less => :copy_files do 
+task :compile_less => :copy_files do
   `lessc lib/html/includes.less > lib/html/includes.css`
 end
 
@@ -35,5 +35,6 @@ task :copy_files do
   `ln -s #{path}/list.js lib/html/list.js`
   `ln -s #{path}/list.tmpl lib/html/list.tmpl`
   `ln -s #{path}/include.partial.html lib/html/profile_handler.js`
+  `ln -s #{path}/share.html lib/html/share.html`
 end
 

--- a/StackExchange.Profiling/UI/include.partial.html
+++ b/StackExchange.Profiling/UI/include.partial.html
@@ -1,6 +1,6 @@
-﻿<script type="text/javascript">    
+﻿<script type="text/javascript">
     (function(){{
-        var init = function() {{        
+        var init = function() {{
                 var load = function(s,f){{
                     var sc = document.createElement('script');
                     sc.async = 'async';
@@ -14,8 +14,8 @@
                     }};
 
                     document.getElementsByTagName('head')[0].appendChild(sc);
-                }};                
-                
+                }};
+
                 var initMp = function(){{
                     load('{path}includes.js?v={version}',function(){{
                         MiniProfiler.init({{
@@ -32,18 +32,18 @@
                         }});
                     }});
                 }};
-                if ({useExistingjQuery}) {{
+                if ({useExistingjQuery} && typeof(jQuery) === 'function') {{
                     jQueryMP = jQuery;
                     initMp();
                 }} else {{
                     load('{path}jquery.1.7.1.js?v={version}', initMp);
                 }}
-                
+
         }};
 
-        var w = 0;        
+        var w = 0;
         var f = false;
-        var deferInit = function(){{ 
+        var deferInit = function(){{
             if (f) return;
             if (window.performance && window.performance.timing && window.performance.timing.loadEventEnd == 0 && w < 10000){{
                 setTimeout(deferInit, 100);


### PR DESCRIPTION
Pull #53 is great but just a small issue: it breaks the 'share' page because even when `useExistingjQuery` is true, the share page is a standalone html page, which should use the vendored jQuery one. This checks for jQuery's existence to require loading jQuery first when applicable

I also think the 'share.html' page should be symlinked over Rakefile like the rest under `rake copy_files` task. Let me know if that's not supposed to be I can undo that change
