### PR TITLE
Be YAJL friendly

### DIFF
--- a/Ruby/Gemfile.lock
+++ b/Ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-mini-profiler (0.1.8)
+    rack-mini-profiler (0.1.9)
       rack (>= 1.1.3)
 
 GEM

--- a/Ruby/lib/mini_profiler/timer_struct.rb
+++ b/Ruby/lib/mini_profiler/timer_struct.rb
@@ -22,7 +22,12 @@ module Rack
       end
 
       def to_json(*a)
-        ::JSON.generate(@attributes, a[0])
+        if a[0] == nil
+          # YAJL doesnt like nil as options
+          ::JSON.generate( @attributes )
+        else
+          ::JSON.generate(@attributes, a[0])
+        end
       end
 
     end

--- a/Ruby/spec/components/timer_struct_spec.rb
+++ b/Ruby/spec/components/timer_struct_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'mini_profiler/timer_struct'
 
+require 'json'
+
 describe Rack::MiniProfiler::TimerStruct do
 
   before do
@@ -25,6 +27,16 @@ describe Rack::MiniProfiler::TimerStruct do
 
     it 'has a JSON value' do
       @json.should_not be_nil
+    end
+
+    it 'should not add a second (nil) argument if no arguments were passed' do
+      ::JSON.should_receive( :generate ).once.with( @timer.attributes ).and_return( nil )
+      @timer.to_json
+    end
+
+    it 'should pass given arguments' do
+      ::JSON.should_receive( :generate ).once.with( @timer.attributes, :foo => true ).and_return( nil )
+      @timer.to_json( :foo => true )
     end
 
     describe 'deserialized' do


### PR DESCRIPTION
YAJL is used in many rails projects as an optimized JSON (de)serializer. The ruby implementation of YAJL doesn't like nil passed as a second parameter to JSON.generate and expects some kind of hash. If nil is passed, exceptions are thrown.

This patch will refrain from adding a second argument to the JSON.generate call if none was passed to the Rack::MiniProfiler::TimerStruct#to_json call.
