### PR TITLE
fix issue with yajl-ruby json gem

### DIFF
--- a/Ruby/lib/mini_profiler/timer_struct.rb
+++ b/Ruby/lib/mini_profiler/timer_struct.rb
@@ -22,7 +22,7 @@ module Rack
       end
 
       def to_json(*a)
-        ::JSON.generate(@attributes, a[0])
+        ::JSON.generate(@attributes, a[0] || {})
       end
 
     end


### PR DESCRIPTION
I tried using MiniProfiler in an app that uses the [yajl-ruby json gem compatibility api](https://github.com/brianmario/yajl-ruby#json-gem-compatibility-api) and noticed that on every page load that MiniProfiler was not displayed and a NoMethodError: undefined method has_key? for nil:NilClass error appeared in the logs.

This appears to be a bug with yajl-ruby since the vanilla json implementation handles this just fine.  I have submitted a PR on that project but I thought it would also be a good idea to fix it here since it is an easy fix and probably gets MiniProfiler working right now for a non-trivial amount of users.
