### PR TITLE
Settings.Storage threw NullReferenceException

### DIFF
--- a/StackExchange.Profiling/UI/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/UI/MiniProfilerHandler.cs
@@ -154,7 +154,9 @@ namespace StackExchange.Profiling.UI
             if (!lastId.IsNullOrWhiteSpace()) {
                 Guid.TryParse(lastId, out lastGuid);
             }
-            
+
+            //After app restart, MiniProfiler.Settings.Storage will be null if no results saved, and NullReferenceException is thrown.
+            if(MiniProfiler.Settings.Storage == null) { MiniProfiler.Settings.EnsureStorageStrategy(); }
             var guids = MiniProfiler.Settings.Storage.List(100);
 
             if (lastGuid != Guid.Empty)


### PR DESCRIPTION
After app restart, MiniProfiler.Settings.Storage will be null if no results saved ==> NullReferenceException is thrown.
Actual change is same as in #61, this time git isn't confused...
