### PR TITLE
Add clientTimings to all AJAX requests (TAKE3)

### DIFF
--- a/Sample.Mvc/Views/Home/Index.cshtml
+++ b/Sample.Mvc/Views/Home/Index.cshtml
@@ -55,11 +55,15 @@
                 type: 'GET',
                 url: $clicked[0].href,
                 success: function(data) {
+                    if (window.mPt) mPt.probe("Processing ajax response.");
+
                     var $p = $('<p class="ajax-result">'),
                         transform = $clicked.data('transform');
 
                     $p.append(transform ? window[transform](data) : data);
                     $results.append($p);
+                    
+                    if (window.mPt) mPt.probe("Processing ajax response.");
                 },
                 error: function() { $results.append('ERROR!'); },
                 complete: function() { $spinner.remove(); }

--- a/StackExchange.Profiling/ClientTimingHelper.cs
+++ b/StackExchange.Profiling/ClientTimingHelper.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Profiling
         /// <summary>
         /// This code needs to be inserted in the page before client timings work
         /// </summary>
-        public const string InitScript = "<script type='text/javascript'>mPt=function(){var t=[];return{t:t,probe:function(n){t.push({d:new Date(),n:n})}}}()</script>";
+        public const string InitScript = "<script type='text/javascript'>mPt=function(){var t=[];return{results:function(){return t},probe:function(n){t.push({d:new Date(),n:n})},flush:function(){t=[]}}}()</script>";
 
         /// <summary>
         /// You can wrap an html block with timing wrappers using this helper

--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -5,7 +5,8 @@ var MiniProfiler = (function ($) {
         container,
         controls,
         fetchedIds = [],
-        fetchingIds = []  // so we never pull down a profiler twice
+        fetchingIds = [], // so we never pull down a profiler twice
+        ajaxStartTime
         ;
 
     var hasLocalStorage = function () {
@@ -73,15 +74,15 @@ var MiniProfiler = (function ($) {
             clientPerformance = null;
             clientProbes = null;
 
-            if (id == options.currentId) {
-
-                if (window.mPt) {
-                    clientProbes = mPt.t;
-                    for (j = 0; j < clientProbes.length; j++) {
-                        clientProbes[j].d = clientProbes[j].d.getTime();
-                    }
-                    mPt.t = [];
+            if (window.mPt) {
+                clientProbes = mPt.results();
+                for (j = 0; j < clientProbes.length; j++) {
+                    clientProbes[j].d = clientProbes[j].d.getTime();
                 }
+                mPt.flush();
+            }
+            
+            if (id == options.currentId) {
 
                 clientPerformance = getClientPerformance();
 
@@ -113,6 +114,9 @@ var MiniProfiler = (function ($) {
 
                     }
                 }
+            } else if (ajaxStartTime != null && clientProbes.length > 0) {
+                clientPerformance = { timing: { navigationStart: ajaxStartTime.getTime() } };
+                ajaxStartTime = null;
             }
 
             if ($.inArray(id, fetchedIds) < 0 && $.inArray(id, fetchingIds) < 0) {
@@ -449,6 +453,9 @@ var MiniProfiler = (function ($) {
             jQuery(document).ajaxComplete(jQueryAjaxComplete);
         }
 
+        if (jQuery(document).ajaxStart)
+            jQuery(document).ajaxStart(function () { ajaxStartTime = new Date(); });
+        
         // fetch results after ASP Ajax calls
         if (typeof (Sys) != 'undefined' && typeof (Sys.WebForms) != 'undefined' && typeof (Sys.WebForms.PageRequestManager) != 'undefined') {
             // Get the instance of PageRequestManager.


### PR DESCRIPTION
-Changed the mPt scoping to add a flush method
-Changed include.js to pass clientTimings on all AJAX requests with synthetic navigationStart
-Changed the Sample.MVC to demonstrate
