### PR TITLE
Initialize config.skip_paths in all environments

### DIFF
--- a/Ruby/lib/mini_profiler_rails/railtie.rb
+++ b/Ruby/lib/mini_profiler_rails/railtie.rb
@@ -12,8 +12,9 @@ module MiniProfilerRails
         Rails.env.development? || Rails.env.production?  
       }
 
+      c.skip_paths ||= []
+
       if Rails.env.development?
-        c.skip_paths ||= []
         c.skip_paths << "/assets/"
         c.skip_schema_queries = true
       end


### PR DESCRIPTION
Doesn't really cost anything, and you still want to skip some paths (e.g. `/admin`) in production.
