### PR TITLE
Use SHA256CryptoServiceProvider instead of SHA256. This prevents an exception from being thrown.

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.Settings.cs
+++ b/StackExchange.Profiling/MiniProfiler.Settings.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Profiling
                         files.AddRange(System.IO.Directory.EnumerateFiles(customUITemplatesPath));
                     }
 
-                    using (var sha256 = System.Security.Cryptography.SHA256.Create())
+                    using (var sha256 = new System.Security.Cryptography.SHA256CryptoServiceProvider())
                     {
                         byte[] hash = new byte[sha256.HashSize / 8];
                         foreach (string file in files)


### PR DESCRIPTION
SHA256 will still thrown the FIPS Exception on a Windows machine with
the FIPS registry flag enabled. However, using
SHA256CryptoServiceProvider will not throw cause a FIPS exception to be
thrown. See
http://stackoverflow.com/questions/3554882/difference-between-sha256cryptoserviceprovider-and-sha256managed
