### PR TITLE
Avoid deprecated Proc#bind when instance_exec available

### DIFF
--- a/Ruby/lib/mini_profiler/profiling_methods.rb
+++ b/Ruby/lib/mini_profiler/profiling_methods.rb
@@ -71,8 +71,16 @@ module Rack
           return self.send without_profiling, *args, &orig unless Rack::MiniProfiler.current
 
           name = default_name 
-          name = blk.bind(self).call(*args) if blk
-          
+          if blk
+            name =
+              if respond_to?(:instance_exec)
+                instance_exec(*args, &blk)
+              else
+                # deprecated in Rails 4.x
+                blk.bind(self).call(*args)
+              end
+          end
+
           parent_timer = Rack::MiniProfiler.current.current_timer
           page_struct = Rack::MiniProfiler.current.page_struct
           result = nil


### PR DESCRIPTION
`Proc#bind` is deprecated in https://github.com/rails/rails/pull/5552 due to some pretty serious GC issues with the implementation. In addition to just being something to avoid, its dumping one of these messages per template in the server logs:

```
 DEPRECATION WARNING: Proc#bind is deprecated and will be removed in future versions. (called
 from block in profile_method at vendor/gems/ruby/1.9.1/gems/rack-mini-profiler-0.1.20/lib/mini_profiler/profiling_methods.rb:74)
```

This change uses `Object#instance_exec` (Ruby >= 1.9) instead when available. `Proc#bind` is still used in environments that don't have `instance_exec`.
