### PR TITLE
Rails 4.x fix

### DIFF
--- a/Ruby/lib/rack-mini-profiler.rb
+++ b/Ruby/lib/rack-mini-profiler.rb
@@ -1,6 +1,6 @@
 require 'mini_profiler/profiler'
 require 'patches/sql_patches'
 
-if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3
+if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
   require 'mini_profiler_rails/railtie'
 end


### PR DESCRIPTION
This adjusts the conditional in `rack-mini-profiler.rb` to load the Railtie under any version of Rails >= 3. This should be sane since the Railtie interface is -- I think -- something the Rails team is committed to maintaining compatibility for going forward.
