### PR TITLE
Use SHA256CryptoServiceProvider instead of SHA256. This prevents a FIPS exception from being thrown.

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.Settings.cs
+++ b/StackExchange.Profiling/MiniProfiler.Settings.cs
@@ -58,12 +58,12 @@ namespace StackExchange.Profiling
                         files.AddRange(System.IO.Directory.EnumerateFiles(customUITemplatesPath));
                     }
 
-                    using (var sha256 = System.Security.Cryptography.SHA256.Create())
+                    using (var sha256 = new System.Security.Cryptography.SHA256CryptoServiceProvider())
                     {
                         byte[] hash = new byte[sha256.HashSize / 8];
                         foreach (string file in files)
                         {
-                            // sha256 is FIPS BABY - FIPS 
+                            // sha256 can throw a FIPS exception, but SHA256CryptoServiceProvider is FIPS BABY - FIPS 
                             byte[] contents = System.IO.File.ReadAllBytes(file);
                             byte[] hashfile = sha256.ComputeHash(contents);
                             for (int i = 0; i < (sha256.HashSize / 8); i++)


### PR DESCRIPTION
While SHA256 is a FIPS-compliant algorithm, the instance created by `SHA256.Create()` will still cause an exception to be thrown when the FIPS flagged is enabled on a Windows Machine. Use `new SHA256CryptoServiceProvider()` instead, which will not cause the FIPS exception to be thrown.
