### PR TITLE
Supporting non-default Entity Framework setups

### DIFF
--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ClientTimingHelper.cs" />
     <Compile Include="MVCHelpers\ProfilingActionFilter.cs" />
     <Compile Include="MVCHelpers\ProfilingViewEngine.cs" />
+    <Compile Include="MVCHelpers\WrappedView.cs" />
     <Compile Include="SqlFormatters\InlineFormatter.cs" />
     <Compile Include="SqlFormatters\ISqlFormatter.cs" />
     <Compile Include="SqlFormatters\OracleFormatter.cs" />

--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -364,6 +364,9 @@ var MiniProfiler = (function ($) {
                 popupHide(button, popup);
             }
         });
+        $(document).on('click', '.profiler-button span.close', function(){
+            $(this).parent('profiler-result').remove();
+        });
     };
 
     var initFullView = function () {

--- a/StackExchange.Profiling/UI/includes.tmpl
+++ b/StackExchange.Profiling/UI/includes.tmpl
@@ -3,6 +3,7 @@
   <div class="profiler-result">
 
     <div class="profiler-button {{if HasDuplicateSqlTimings}}profiler-warning{{/if}}">
+    <span class="close">x</span>
     {{if HasDuplicateSqlTimings}}<span class="profiler-nuclear">!</span>{{/if}}
       <span class="profiler-number">
         ${MiniProfiler.formatDuration(DurationMilliseconds)} <span class="profiler-unit">ms</span>


### PR DESCRIPTION
The default paths for the workspace did not work with our particular entity framework setup.  We would get an exception when trying to profile the Entity Framework.

I needed to support multiple edmxs, and be able pass in resource paths for the Object Context creation.  

I also had to support multiple metadata workspaces in the MetadataCache.  I tried to write a few methods that would support most cases for Object Context creation.  Its working for us now.
