### PR TITLE
Adding support for multiple edmx files in one or more assemblies

### DIFF
--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ClientTimingHelper.cs" />
     <Compile Include="MVCHelpers\ProfilingActionFilter.cs" />
     <Compile Include="MVCHelpers\ProfilingViewEngine.cs" />
+    <Compile Include="MVCHelpers\WrappedView.cs" />
     <Compile Include="SqlFormatters\InlineFormatter.cs" />
     <Compile Include="SqlFormatters\ISqlFormatter.cs" />
     <Compile Include="SqlFormatters\OracleFormatter.cs" />


### PR DESCRIPTION
**Note:** This is https://github.com/SamSaffron/MiniProfiler/pull/74, but with the line endings fixed

The default paths for the workspace did not work with our particular
entity framework setup.  I needed to support multiple edmxs, and be able
pass in resource paths for the Object Context creation.  I also had to
support multiple metadata workspaces
