### PR TITLE
Allow users to specify different connection options for the redis store

### DIFF
--- a/Ruby/lib/mini_profiler/storage/redis_store.rb
+++ b/Ruby/lib/mini_profiler/storage/redis_store.rb
@@ -5,8 +5,8 @@ module Rack
       EXPIRE_SECONDS = 60 * 60 * 24
      
       def initialize(args)
-        args ||= {}
-        @prefix = args[:prefix] || 'MPRedisStore'
+        @args = args || {}
+        @prefix = @args.delete(:prefix) || 'MPRedisStore'
       end
 
       def save(page_struct)
@@ -36,7 +36,7 @@ module Rack
 
       def redis
         require 'redis' unless defined? Redis
-        Redis.new 
+        Redis.new @args
       end
 
     end

--- a/Ruby/spec/components/redis_store_spec.rb
+++ b/Ruby/spec/components/redis_store_spec.rb
@@ -6,6 +6,28 @@ require 'mini_profiler/storage/redis_store'
 
 describe Rack::MiniProfiler::RedisStore do
 
+  context 'establishing a connection to something other than the default' do
+    before do
+      @store = Rack::MiniProfiler::RedisStore.new(:db=>2)
+    end
+
+    describe "connection" do
+      it 'can still store the resulting value' do
+        page_struct = Rack::MiniProfiler::PageTimerStruct.new({})
+        page_struct['Id'] = "XYZ"
+        page_struct['Random'] = "random"
+        @store.save(page_struct)
+      end
+
+      it 'uses the correct db' do
+        # redis is private, and possibly should remain so?
+        underlying_client = @store.send(:redis).client
+
+        underlying_client.db.should == 2
+      end
+    end
+  end
+
   context 'page struct' do
 
     before do


### PR DESCRIPTION
This allows you to use redis running on alternative hosts etc without having to create a subclass and override the private redis method.
