### PR TITLE
Support environments other than production and development by default

### DIFF
--- a/Ruby/lib/mini_profiler_rails/railtie.rb
+++ b/Ruby/lib/mini_profiler_rails/railtie.rb
@@ -9,7 +9,7 @@ module MiniProfilerRails
 
       # By default, only show the MiniProfiler in development mode, in production allow profiling if post_authorize_cb is set
       c.pre_authorize_cb = lambda { |env|
-        Rails.env.development? || Rails.env.production?  
+        !Rails.env.test?
       }
 
       c.skip_paths ||= []


### PR DESCRIPTION
I spent a bunch of time tracking this one down,  on our staging servers Rails.env == staging.  So miniprofiler wasn't running at all.
