### PR TITLE
Fix issue with jQuery 1.8.1.

### DIFF
--- a/Ruby/lib/mini_profiler/client_timer_struct.rb
+++ b/Ruby/lib/mini_profiler/client_timer_struct.rb
@@ -36,7 +36,7 @@ module Rack
 
         probes = form['clientProbes']
         translated = {}
-        if probes && probes != "null"
+        if probes && !["null", ""].include?(probes)
           probes.each do |id, val|
             name = val["n"]
             translated[name] ||= {} 

--- a/Ruby/spec/fixtures/weird_client_request.yml
+++ b/Ruby/spec/fixtures/weird_client_request.yml
@@ -1,5 +1,6 @@
 --- 
 rack.request.form_hash:
+  clientProbes: ''
   clientPerformance: 
     navigation:
       redirectCount: 99


### PR DESCRIPTION
I recently upgraded from jQuery 1.7.2 to 1.8.1 in a Rails app, and noticed this error in my logs:

```
[2012-09-26 01:05:19] ERROR NoMethodError: undefined method `each' for "":String
    /Users/fijabakk/src/git/MiniProfiler/Ruby/lib/mini_profiler/client_timer_struct.rb:40:in `init_from_form_data'
    /Users/fijabakk/src/git/MiniProfiler/Ruby/lib/mini_profiler/profiler.rb:111:in `serve_results'
    /Users/fijabakk/src/git/MiniProfiler/Ruby/lib/mini_profiler/profiler.rb:139:in `serve_html'
    /Users/fijabakk/src/git/MiniProfiler/Ruby/lib/mini_profiler/profiler.rb:195:in `call'
```

The app is using the `use_existing_jquery` setting. It looks like jQuery may be serializing null differently than before (though I haven't tried to track down the exact version that introduced the change). 

This PR fixes the issue by checking for an empty string in addition to `"null"`. I added the empty value to `spec/fixtures/weird_client_request.yml` so it's caught by the specs.

Thanks for an awesome tool!
