### PR TITLE
Set User in result page struct

### DIFF
--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -316,6 +316,7 @@ module Rack
       end
       
       page_struct = current.page_struct
+      page_struct['User'] = user(env)
 			page_struct['Root'].record_time((Time.now - start) * 1000)
 
       if backtraces
@@ -325,7 +326,7 @@ module Rack
       
 
       # no matter what it is, it should be unviewed, otherwise we will miss POST
-      @storage.set_unviewed(user(env), page_struct['Id']) 
+      @storage.set_unviewed(page_struct['User'], page_struct['Id'])
 			@storage.save(page_struct)
 			
       # inject headers, script


### PR DESCRIPTION
The top-level `'User'` attribute in the result JSON is set to `'unknown user'` in `PageTimerStruct` and never updated to a real value anywhere that I can see. It's useful to have a valid value here for troubleshooting issues with users stomping and stealing each other's results.

Also uses the already calculated value to prevent creating a new `Rack::Request` each time the user is needed as happens with the default user provider.

This is just something I was playing around with while troubleshooting and figured I'd send it over. No biggie if it isn't interesting to you.
