### PR TITLE
Fix for failure Rack::MiniProfiler (rake spec)

### DIFF
--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -127,7 +127,7 @@ module Rack
         html.gsub!(/\{json\}/, result_json)
         html.gsub!(/\{includes\}/, get_profile_script(env))
         html.gsub!(/\{name\}/, page_struct['Name'])
-        html.gsub!(/\{duration\}/, page_struct.duration_ms.round(1).to_s)
+        html.gsub!(/\{duration\}/, '.2%f' % page_struct.duration_ms)
         
         [200, {'Content-Type' => 'text/html'}, [html]]
       end


### PR DESCRIPTION
Fix for 'Rack::MiniProfiler with a valid request has a functioning share link', when running 'rake spec'.

  1) Rack::MiniProfiler with a valid request has a functioning share link
     Failure/Error: get "/mini-profiler-resources/results?id=#{id}"
     ArgumentError:
       wrong number of arguments (1 for 0)
     # ./lib/mini_profiler/profiler.rb:130:in `round'
     # ./lib/mini_profiler/profiler.rb:130:in`serve_results'
     # ./lib/mini_profiler/profiler.rb:139:in `serve_html'
     # ./lib/mini_profiler/profiler.rb:195:in`call'
     # ./spec/integration/mini_profiler_spec.rb:75

Running on:
    interpreter:  "ruby"
    version:      "1.8.7"
    date:         "2011-12-28"
    platform:     "i686-darwin11.2.0"
    patchlevel:   "2011-12-28 patchlevel 357"
    full_version: "ruby 1.8.7 (2011-12-28 patchlevel 357) [i686-darwin11.2.0]"
