### PR TITLE
Detach ruby version to new project

### DIFF
--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -128,3 +128,4 @@ end
 
 If you include the query string `pp=help` at the end of your request you will see the various option you have. You can use these options to extend or contract the amount of diagnostics rack-mini-profiler gathers. 
 
+\nDetach Ruby project


### PR DESCRIPTION
It would be great to have a "standard" rubygem structure from rack-mini-profiler. The main objective, that you can use the "edge" by pointing to git via bundler and configure Travis to run specs. And must be any others!

Example in a Gemfile:

gem "rack-mini-profiler", :git => "http://new-repoistory-on-github"

What do you guys think? If all agree, i do the job!
