### PR TITLE
Check existing jQuery version

### DIFF
--- a/Ruby/lib/mini_profiler/config.rb
+++ b/Ruby/lib/mini_profiler/config.rb
@@ -14,8 +14,11 @@ module Rack
 
     attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
         :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries, 
-        :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode, :use_existing_jquery
-      
+        :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode
+
+    # Deprecated options
+    attr_accessor :use_existing_jquery
+
       def self.default
         new.instance_eval {
           @auto_inject = true # automatically inject on every html page
@@ -30,7 +33,6 @@ module Rack
           @storage = MiniProfiler::MemoryStore
           @user_provider = Proc.new{|env| Rack::Request.new(env).ip}
           @authorization_mode = :allow_all
-          @use_existing_jquery = false
           self
         }
       end

--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -491,11 +491,10 @@ module Rack
 			showControls = false
 			currentId = current.page_struct["Id"]
 			authorized = true
-			useExistingjQuery = @config.use_existing_jquery
 			# TODO : cache this snippet 
 			script = IO.read(::File.expand_path('../html/profile_handler.js', ::File.dirname(__FILE__)))
 			# replace the variables
-			[:ids, :path, :version, :position, :showTrivial, :showChildren, :maxTracesToShow, :showControls, :currentId, :authorized, :useExistingjQuery].each do |v|
+			[:ids, :path, :version, :position, :showTrivial, :showChildren, :maxTracesToShow, :showControls, :currentId, :authorized].each do |v|
 				regex = Regexp.new("\\{#{v.to_s}\\}")
 				script.gsub!(regex, eval(v.to_s).to_s)
 			end

--- a/StackExchange.Profiling/UI/include.partial.html
+++ b/StackExchange.Profiling/UI/include.partial.html
@@ -16,7 +16,6 @@
 
         load('{path}includes.js?v={version}',function(){{
             MiniProfiler.init({{
-                usingExistingjQuery: {useExistingjQuery},
                 ids: {ids},
                 path: '{path}',
                 version: '{version}',

--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -580,7 +580,10 @@ var MiniProfiler = (function () {
                 }
             }
 
-            if (options.useExistingjQuery && typeof(jQuery) === 'function') {
+            if (typeof(jQuery) == 'function') {
+                var jQueryVersion = jQuery.fn.jquery.split('.');
+            }
+            if (jQueryVersion && parseInt(jQueryVersion[0]) < 2 && parseInt(jQueryVersion[1]) >= 7) {
                 MiniProfiler.jQuery = $ = jQuery;
                 $(deferInit);
             } else {


### PR DESCRIPTION
Tested MiniProfiler working back to jQuery 1.4.0. Though, I don't think we want to support that far back. Its probably safe to require a minimal of whatever version MiniProfiler bundles itself, thats 1.7.x. I feel pretty confident that 1.9.x, the last 1.x version of jQuery, is going to work fine in the future. So 1.7.x to 2.x seems like a good version constraint.

I removed `useExistingJquery` from a few spots in the ruby code, but I'm not sure about the .net code path. It'd probably be good to ensure that any existing configuration code setting `useExistingJquery` doesn't explode, but is just silent.
