### PR TITLE
Sql Server Spatial support

### DIFF
--- a/StackExchange.Profiling.EntityFramework/ProfiledDbProviderServices.cs
+++ b/StackExchange.Profiling.EntityFramework/ProfiledDbProviderServices.cs
@@ -66,6 +66,25 @@ namespace StackExchange.Profiling.Data
             return wrapped.DatabaseExists(GetRealConnection(connection), commandTimeout, storeItemCollection);
         }
 
+        protected override System.Data.Spatial.DbSpatialServices DbGetSpatialServices(string manifestToken)
+        {
+            return wrapped.GetSpatialServices(manifestToken);
+        }
+        protected override System.Data.Spatial.DbSpatialDataReader GetDbSpatialDataReader(DbDataReader fromReader, string manifestToken)
+        {
+            return wrapped.GetSpatialDataReader(GetRealDataReader(fromReader), manifestToken);
+        }
+
+        private static DbDataReader GetRealDataReader(DbDataReader reader)
+        {
+            var profiled = reader as ProfiledDbDataReader;
+            if (profiled != null)
+            {
+                reader = profiled.WrappedReader;
+            }
+            return reader;
+        }
+
         /// <summary>
         /// Get DB command definition
         /// </summary>

--- a/StackExchange.Profiling.EntityFramework/StackExchange.Profiling.EntityFramework.csproj
+++ b/StackExchange.Profiling.EntityFramework/StackExchange.Profiling.EntityFramework.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StackExchange.Profiling.EntityFramework</RootNamespace>
     <AssemblyName>MiniProfiler.EntityFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/StackExchange.Profiling/Data/ProfiledDbDataReader.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbDataReader.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Profiling.Data
         private DbConnection _conn;
         private DbDataReader _reader;
         private IDbProfiler _profiler;
-
+        public DbDataReader WrappedReader { get { return _reader; } }
 
         public ProfiledDbDataReader(DbDataReader reader, DbConnection connection, IDbProfiler profiler)
         {


### PR DESCRIPTION
A very simple addition to support spatial data types in SQL Server. Addresses this error:

http://community.miniprofiler.com/permalinks/36/the-provider-did-not-return-a-dbspatialservices-instance

I've tested basic reading and writing of entities using EF 5, but nothing else. And, given this was my very first usage of spatial data types, well, buyer beware!

The big hitch is it requires targeting .net 4.5. I'm not entirely sure what the best way will be to handle that, but once 4.5 is available the code changes are pretty minor.

Murray
