### PR TITLE
Add ability to ignore sections of a profiled step or database profiling

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.IDbProfiler.cs
+++ b/StackExchange.Profiling/MiniProfiler.IDbProfiler.cs
@@ -141,7 +141,10 @@ namespace StackExchange.Profiling
 
         bool _isActive;
         bool IDbProfiler.IsActive { get { return _isActive; } }
-        internal bool IsActive { set { _isActive = value; } }
-
+        internal bool IsActive
+        {
+            get { return _isActive; }
+            set { _isActive = value; }
+        }
     }
 }

--- a/StackExchange.Profiling/MiniProfiler.cs
+++ b/StackExchange.Profiling/MiniProfiler.cs
@@ -408,6 +408,15 @@
         }
 
         /// <summary>
+        /// The ignore implementation.
+        /// </summary>
+        /// <returns>the step.</returns>
+        internal IDisposable IgnoreImpl()
+        {
+            return new Suppression(this);
+        }
+
+        /// <summary>
         /// The stop implementation
         /// </summary>
         /// <returns>true if the profile is stopped.</returns>

--- a/StackExchange.Profiling/MiniProfilerExtensions.cs
+++ b/StackExchange.Profiling/MiniProfilerExtensions.cs
@@ -41,6 +41,20 @@
         }
 
         /// <summary>
+        /// Returns an <see cref="IDisposable"/> that will ignore profiling between its creation and disposal.
+        /// </summary>
+        /// <remarks>
+        /// This is mainly useful in situations where you want to ignore database profiling for known hot spots,
+        /// but it is safe to use in a nested step such that you can ignore sub-sections of a profiled step.
+        /// </remarks>
+        /// <param name="profiler">The current profiling session or null.</param>
+        /// <returns>the profile step</returns>
+        public static IDisposable Ignore(this MiniProfiler profiler)
+        {
+            return profiler == null ? null : profiler.IgnoreImpl();
+        }
+        
+        /// <summary>
         /// Adds <paramref name="externalProfiler"/>'s <see cref="Timing"/> hierarchy to this profiler's current Timing step,
         /// allowing other threads, remote calls, etc. to be profiled and joined into this profiling session.
         /// </summary>

--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -63,6 +63,7 @@
       <DependentUpon>IProfilerProvider.cs</DependentUpon>
     </Compile>
     <Compile Include="ClientTimings.cs" />
+    <Compile Include="Suppression.cs" />
     <Compile Include="Data\ExecuteType.cs" />
     <Compile Include="Data\IDbProfiler.cs" />
     <Compile Include="Data\SimpleProfiledCommand.cs" />

--- a/StackExchange.Profiling/Suppression.cs
+++ b/StackExchange.Profiling/Suppression.cs
@@ -1,0 +1,64 @@
+﻿namespace StackExchange.Profiling
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// An individual suppression block that deactivates profiling temporarily
+    /// </summary>
+    [DataContract]
+    public class Suppression : IDisposable
+    {
+        private readonly bool _wasSuppressed;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Suppression"/> class. 
+        /// Obsolete - used for serialization.
+        /// </summary>
+        [Obsolete("Used for serialization")]
+        public Suppression()
+        {
+
+        }
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Suppression"/> class. 
+        /// Creates a new Suppression to deactive profiling while alive
+        /// </summary>
+        /// <param name="profiler">
+        /// The profiler.
+        /// </param>
+        public Suppression(MiniProfiler profiler)
+        {
+            if (profiler == null)
+            {
+                throw new ArgumentNullException("profiler");
+            }
+
+            Profiler = profiler;
+            if (!Profiler.IsActive)
+            {
+                return;
+            }
+
+            Profiler.IsActive = false;
+            _wasSuppressed = true;
+        }
+
+        /// <summary>
+        /// Gets a reference to the containing profiler, allowing this Suppression to affect profiler activity.
+        /// </summary>
+        internal MiniProfiler Profiler { get; private set; }
+
+        /// <summary>
+        /// dispose the profiler.
+        /// </summary>
+        void IDisposable.Dispose()
+        {
+            if(Profiler != null && _wasSuppressed)
+            {
+                Profiler.IsActive = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
TL;DR;
Here's a new extension method that lets me willingly ignore code blocks that profile SQL, or subsections of code blocks I'm already profiling.

Here's a pretend use case:
I have a profiled page that's showing multiple duplicate SQL warnings because I'm batching up user events and flushing them at the end of a request. I'm using SQLite or I've decided it's not worth bulk inserting these records. Forgetting the bad practice of blocking a request while I insert stuff in the database, I don't want a reminder on each profile load that I am using the same SQL to make multiple inserts because it might hide other real problems I don't know about. Or, maybe I just want to profile a step and ignore certain bits of it. For that I've added a simple `Ignore` extension that takes advantage of the internal IsActive flag to turn profiling on and off. I didn't have to make any invasive changes to the core, but I did have to add an internal getter for IsActive because I didn't want to reactivate prematurely if other extensions eventually use the same flag.

Usage:

``` csharp
using(MiniProfiler.Current.Step("I want to profile some stuff but not other stuff"))
{
    Thread.Sleep(2000); // Lalala stuff...

    using (MiniProfiler.Current.Ignore())
    {
        // INSERT INTO...
        // INSERT INTO...
        // INSERT INTO...
        // INSERT INTO...
        UnitOfWork.Current.BulkCopy(stuff);
    }    
}
```
