### PR TITLE
Add AJAX profiling support for MooTools

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -508,6 +508,18 @@ var MiniProfiler = (function () {
             });
         }
 
+        if (typeof (MooTools) != 'undefined' && typeof (Request) != 'undefined') {
+          Request.prototype.addEvents({
+            onComplete: function() {
+              var stringIds = this.xhr.getResponseHeader('X-MiniProfiler-Ids');
+              if (stringIds) {
+                var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
+                fetchResults(ids);
+              }
+            }
+          });
+        }
+
         // some elements want to be hidden on certain doc events
         bindDocumentEvents();
     };


### PR DESCRIPTION
I started using MiniProfiler on a rails project that uses MooTools instead jQuery. Ajax calls were displayed only after page reload so I added this changes to make it work.

Note that I have 3 failing tests when i run `bundle exec rake spec` but I don't have memcached installed.

``` bash
Finished in 0.71693 seconds
116 examples, 3 failures

Failed examples:

rspec ./spec/components/memcache_store_spec.rb:17 # Rack::MiniProfiler::MemcacheStore page struct storage can store a PageStruct and retrieve it
rspec ./spec/components/memcache_store_spec.rb:27 # Rack::MiniProfiler::MemcacheStore page struct storage can list unviewed items for a user
rspec ./spec/components/memcache_store_spec.rb:35 # Rack::MiniProfiler::MemcacheStore page struct storage can set an item to viewed once it is unviewed

```
