### PR TITLE
Add AJAX profiling support for AngularJS

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -521,7 +521,7 @@ var MiniProfiler = (function () {
         }
 
         // add support for AngularJS, which use the basic XMLHttpRequest object.
-        if (angular && typeof (XMLHttpRequest) != 'undefined') {
+        if (window.angular && typeof (XMLHttpRequest) != 'undefined') {
           var _send = XMLHttpRequest.prototype.send;
 
           XMLHttpRequest.prototype.send = function sendReplacement(data) {


### PR DESCRIPTION
If you find a better way to:
1. determine AngularJS is present
2. add a callback on every Ajax request handled by AngularJS

Let me know! :)
