### PR TITLE
Updated TableCreationScript for SQL Azure

### DIFF
--- a/StackExchange.Profiling/Storage/SqlServerStorage.cs
+++ b/StackExchange.Profiling/Storage/SqlServerStorage.cs
@@ -520,7 +520,8 @@ where not exists (select 1 from MiniProfilers where Id = @Id)"; // this syntax w
                 @"
                 create table MiniProfilers
                   (
-                     Id                                   uniqueidentifier not null constraint PK_MiniProfilers primary key nonclustered, -- don't cluster on a guid
+                     RowId                                integer not null identity constraint PK_MiniProfilers primary key clustered, -- Need a clustered primary key for SQL Azure
+                     Id                                   uniqueidentifier not null, -- don't cluster on a guid
                      Name                                 nvarchar(200) not null,
                      Started                              datetime not null,
                      MachineName                          nvarchar(100) null,
@@ -597,6 +598,7 @@ where not exists (select 1 from MiniProfilers where Id = @Id)"; // this syntax w
                 );
                 
                 -- displaying results selects everything based on the main MiniProfilers.Id column
+                create unique nonclustered index IX_MiniProfilers_Id on MiniProfilers (Id)
                 create nonclustered index IX_MiniProfilerTimings_MiniProfilerId on MiniProfilerTimings (MiniProfilerId)
                 create nonclustered index IX_MiniProfilerSqlTimings_MiniProfilerId on MiniProfilerSqlTimings (MiniProfilerId)
                 create nonclustered index IX_MiniProfilerSqlTimingParameters_MiniProfilerId on MiniProfilerSqlTimingParameters (MiniProfilerId)


### PR DESCRIPTION
I've just been using MiniProfiler and setting it up to store the profile results in SQL Azure. I've used the latest [TableCreationScript](https://github.com/SamSaffron/MiniProfiler/blob/85609b6226eff71ac21dfa990dd1fa54aace237f/StackExchange.Profiling/Storage/SqlServerStorage.cs#L511), but it failed because SQL Azure requires all tables to have a primary clustered index.

I also answered this question on [stackoverflow](https://stackoverflow.com/a/14775721/495964) while producing the solution.

The change still works on tradition SQL Server, which I use in development.
