### PR TITLE
Reordered includes and added mandatory attributes for results-index view

### DIFF
--- a/StackExchange.Profiling/UI/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/UI/MiniProfilerHandler.cs
@@ -249,8 +249,8 @@
                 .AppendFormat("<title>List of profiling sessions</title>")
                 .AppendLine()
                 .AppendLine("<script type='text/javascript' src='" + path + "jquery.1.7.1.js?v=" + MiniProfiler.Settings.Version + "'></script>")
+                .AppendLine("<script id='mini-profiler' data-ids='' type='text/javascript' src='" + path + "includes.js?v=" + MiniProfiler.Settings.Version + "'></script>")
                 .AppendLine("<script type='text/javascript' src='" + path + "jquery.tmpl.js?v=" + MiniProfiler.Settings.Version + "'></script>")
-                .AppendLine("<script type='text/javascript' src='" + path + "includes.js?v=" + MiniProfiler.Settings.Version + "'></script>")
                 .AppendLine(
                     "<script type='text/javascript' src='" + path + "list.js?v=" + MiniProfiler.Settings.Version
                     + "'></script>")


### PR DESCRIPTION
Prior changes have changed the way includes.js is used, in the results view the script include has additional attributes defining the profiles to display. These changes seem to have broken the results-index view.

The results-index view failed because:
- jquery.tmpl.js requires MiniProfiler.jQuery from includes.js
- includes.js looks for a script with the id='mini-profiler'
- the attribute data-ids is mandatory

This is a temporary fix as I suspect a correct fix would be to change the JavaScript to handle the absence of these attributes and continue initialisation.
