### PR TITLE
Add support for profiling RSolr requests like SQL

### DIFF
--- a/Ruby/lib/patches/sql_patches.rb
+++ b/Ruby/lib/patches/sql_patches.rb
@@ -187,6 +187,28 @@ if SqlPatches.class_exists?("Moped::Node")
   end
 end
 
+if SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0" #  requires at least v1.0.0
+  class RSolr::Connection
+    alias_method :execute_without_profiling, :execute
+    def execute_with_profiling(client, request_context)
+      current = ::Rack::MiniProfiler.current
+      return execute_without_profiling(client, request_context) unless current
+
+      start = Time.now
+      result = execute_without_profiling(client, request_context)
+      elapsed_time = ((Time.now - start).to_f * 1000).round(1)
+
+      data = "#{request_context[:method].upcase} #{request_context[:uri]}"
+      if request_context[:method] == :post and request_context[:data]
+        data << "\n#{Rack::Utils.unescape(request_context[:data])}"
+      end
+      result.instance_variable_set("@miniprofiler_sql_id", ::Rack::MiniProfiler.record_sql(data, elapsed_time))
+
+      result
+    end
+    alias_method :execute, :execute_with_profiling
+  end
+end
 
 
 # Fallback for sequel


### PR DESCRIPTION
RSolr queries are currently only displaying as network requests which is
not very helpful to debug slow search queries. This patch adds profiling
of RSolr request so they are listed like SQL queries with the displayed
data allowing do build up a manual query using eg. curl.

The profiling hook requires at least RSolr 1.0.0 and ensures it is
available to avoid breakage.

Example output facetted search:

```
POST http://localhost:8983/solr/development/select?wt=ruby
fq=type:Spree\:\:Product&fq=is_active_b:true&sort=score desc&q=macbook&fl=* score&qf=name_text brand_text description_text sku_text vendor_sku_text&defType=dismax&start=0&rows=10&facet=true&facet.query=price_f:[0\.0 TO 10\.0]&facet.query=price_f:[10\.0 TO 50\.0]&facet.query=price_f:[50\.0 TO 100\.0]&facet.query=price_f:[100\.0 TO 500\.0]&facet.query=price_f:[500\.0 TO 800\.0]&facet.query=price_f:[800\.0 TO 1000\.0]&facet.query=price_f:[1000\.0 TO *]&f.taxon_ids_im.facet.mincount=1&facet.field=taxon_ids_im
```

Delete index query:

```
POST http://localhost:8983/solr/development/update?wt=ruby&commit=true
<delete><query>type:Spree\:\:Product</query></delete>
```

If there is no interest for this, I'm happy to simply keep it as an initializer.
