### PR TITLE
Cleanup inconsistent whitespace in rack-mini-profiler

### DIFF
--- a/Ruby/CHANGELOG
+++ b/Ruby/CHANGELOG
@@ -1,77 +1,77 @@
-28-June-2012 - Sam  
- 
+28-June-2012 - Sam
+
   * Started change log
   * Corrected profiler so it properly captures POST requests (was supressing non 200s)
-  * Amended Rack.MiniProfiler.config[:user_provider] to use ip addres for identity 
+  * Amended Rack.MiniProfiler.config[:user_provider] to use ip addres for identity
   * Fixed bug where unviewed missing ids never got cleared
   * Supress all '/assets/' in the rails tie (makes debugging easier)
   * record_sql was mega buggy
   * added MemcacheStore
 
-9-July-2012 - Sam 
+9-July-2012 - Sam
 
   * Cleaned up mechanism for profiling in production, all you need to do now
-	is call Rack::MiniProfiler.authorize_request to get profiling working in
-	production 
-	* Added option to display full backtraces pp=full-backtrace
-	* Cleaned up railties, got rid of the post authorize callback
-	* Version 0.1.3
+  is call Rack::MiniProfiler.authorize_request to get profiling working in
+  production
+  * Added option to display full backtraces pp=full-backtrace
+  * Cleaned up railties, got rid of the post authorize callback
+  * Version 0.1.3
 
-12-July-2012 - Sam 
+12-July-2012 - Sam
 
   * Fixed incorrect profiling steps (was not indenting or measuring start time right
-	* Implemented native PG and MySql2 interceptors, this gives way more accurate times
-	* Refactored context so its a proper class and not a hash 
-	* Added some more client probing built in to rails
-	* More tests
+  * Implemented native PG and MySql2 interceptors, this gives way more accurate times
+  * Refactored context so its a proper class and not a hash
+  * Added some more client probing built in to rails
+  * More tests
 
-18-July-2012 - Sam 
-  
+18-July-2012 - Sam
+
   * Added First Paint time for chrome
   * Bug fix to ensure non Rails installs have mini profiler
   * Version 0.1.7
 
-30-July-2012 - Sam 
-  
+30-July-2012 - Sam
+
   * Made compliant with ancient versions of Rack (including Rack used by Rails2)
-  * Fixed broken share link 
+  * Fixed broken share link
   * Fixed crashes on startup (in MemoryStore and FileStore)
   * Version 0.1.8
-  * Unicode fix 
+  * Unicode fix
   * Version 0.1.9
 
 7-August-2012 - Sam
 
   * Added option to disable profiler for the current session (pp=disable / pp=enable)
-  * yajl compatability contributed by Sven Riedel 
+  * yajl compatability contributed by Sven Riedel
 
-10-August-2012 - Sam 
+10-August-2012 - Sam
 
-  * Added basic prepared statement profiling for postgres 
+  * Added basic prepared statement profiling for postgres
 
-20-August-2012 - Sam 
-  
-  * 1.12.pre 
+20-August-2012 - Sam
+
+  * 1.12.pre
   * Cap X-MiniProfiler-Ids at 10, otherwise the header can get killed
 
 3-September-2012 - Sam
 
   * 1.13.pre
-  * pg gem prepared statements were not being logged correctly 
+  * pg gem prepared statements were not being logged correctly
   * added setting config.backtrace_ignores = [] - an array of regexes that match on caller lines that get ignored
-  * added setting config.backtrace_includes = [] - an array of regexes that get included in the trace by default 
+  * added setting config.backtrace_includes = [] - an array of regexes that get included in the trace by default
   * cleaned up the way client settings are stored
   * made pp=full-backtrace "sticky"
   * added pp=normal-backtrace to clear the "sticky" state
   * change "pp=sample" to work with "caller" no need for stack trace gem
 
-4-September-2012 - Sam 
+4-September-2012 - Sam
 
   * 1.15.pre
-  * fixed annoying bug where client settings were not sticking 
+  * fixed annoying bug where client settings were not sticking
   * fixed long standing issue with Rack::ConditionalGet stopping MiniProfiler from working properly
 
-5-September-2012 - Sam 
+5-September-2012 - Sam
 
   * 1.16
   * fixed long standing problem specs (issue with memory store)
@@ -83,19 +83,19 @@
   * 1.17
   * pp=sample was bust unless stacktrace was installed
 
-10-September-2012 - Sam 
+10-September-2012 - Sam
 
   * 1.19
   * fix compat issue with 1.8.7
 
 12-September-2012 - Sam
-  
+
   * 1.20
   * Added pp=profile-gc , it allows you to profile the GC in Ruby 1.9.3
 
 17-September-2012
   * 1.21
-  * New MemchacedStore 
+  * New MemchacedStore
   * Rails 4 support
 
 17-September-2012

--- a/Ruby/Rakefile
+++ b/Ruby/Rakefile
@@ -13,7 +13,7 @@ end
 
 desc "builds a gem"
 task :build => :update_asset_version do
-  Dir.chdir("..") do 
+  Dir.chdir("..") do
     `gem build rack-mini-profiler.gemspec 1>&2 && mv *.gem Ruby/`
   end
 end
@@ -23,26 +23,27 @@ task :compile_less => :copy_files do
   `lessc lib/html/includes.less > lib/html/includes.css`
 end
 
-desc "update asset version file" 
-task :update_asset_version => :compile_less do 
+desc "update asset version file"
+task :update_asset_version => :compile_less do
   require 'digest/md5'
   h = []
   Dir.glob('lib/html/*.{js,html,css,tmpl}').each do |f|
     h << Digest::MD5.hexdigest(::File.read(f))
   end
-  File.open('lib/mini_profiler/version.rb','w') do |f| 
-    f.write "module Rack
-  class MiniProfiler 
+  File.open('lib/mini_profiler/version.rb','w') do |f|
+    f.write \
+"module Rack
+  class MiniProfiler
     VERSION = '#{Digest::MD5.hexdigest(h.sort.join(''))}'.freeze
   end
-end" 
+end"
   end
 end
 
 
 desc "copy files from other parts of the tree"
 task :copy_files do
-	`rm -R -f lib/html && mkdir lib/html 1>&2`
+  `rm -R -f lib/html && mkdir lib/html 1>&2`
   path = ('../../../StackExchange.Profiling/UI')
   `ln -s #{path}/includes.less lib/html/includes.less`
   `ln -s #{path}/includes.js lib/html/includes.js`

--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -22,9 +22,9 @@ require 'mini_profiler/gc_profiler'
 module Rack
 
   class MiniProfiler
-    
-    class << self 
-      
+
+    class << self
+
       include Rack::MiniProfiler::ProfilingMethods
 
       def generate_id
@@ -44,7 +44,7 @@ module Rack
         return @share_template unless @share_template.nil?
         @share_template = ::File.read(::File.expand_path("../html/share.html", ::File.dirname(__FILE__)))
       end
-      
+
       def current
         Thread.current[:mini_profiler_private]
       end
@@ -103,80 +103,80 @@ module Rack
       end
     end
 
-		#
-		# options:
-		# :auto_inject - should script be automatically injected on every html page (not xhr)
-		def initialize(app, config = nil)
+    #
+    # options:
+    # :auto_inject - should script be automatically injected on every html page (not xhr)
+    def initialize(app, config = nil)
       MiniProfiler.config.merge!(config)
-      @config = MiniProfiler.config 
-			@app = app
-			@config.base_url_path << "/" unless @config.base_url_path.end_with? "/"
+      @config = MiniProfiler.config
+      @app = app
+      @config.base_url_path << "/" unless @config.base_url_path.end_with? "/"
       unless @config.storage_instance
         @config.storage_instance = @config.storage.new(@config.storage_options)
       end
-      @storage = @config.storage_instance 
-		end
-    
+      @storage = @config.storage_instance
+    end
+
     def user(env)
       @config.user_provider.call(env)
     end
 
-		def serve_results(env)
-			request = Rack::Request.new(env)      
+    def serve_results(env)
+      request = Rack::Request.new(env)
       id = request['id']
-			page_struct = @storage.load(id)
+      page_struct = @storage.load(id)
       unless page_struct
-        @storage.set_viewed(user(env), id) 
-        return [404, {}, ["Request not found: #{request['id']} - user #{user(env)}"]] 
+        @storage.set_viewed(user(env), id)
+        return [404, {}, ["Request not found: #{request['id']} - user #{user(env)}"]]
       end
-			unless page_struct['HasUserViewed']
+      unless page_struct['HasUserViewed']
         page_struct['ClientTimings'] = ClientTimerStruct.init_from_form_data(env, page_struct)
-				page_struct['HasUserViewed'] = true
-        @storage.save(page_struct) 
-        @storage.set_viewed(user(env), id) 
-			end
+        page_struct['HasUserViewed'] = true
+        @storage.save(page_struct)
+        @storage.set_viewed(user(env), id)
+      end
 
       result_json = page_struct.to_json
       # If we're an XMLHttpRequest, serve up the contents as JSON
       if request.xhr?
-  			[200, { 'Content-Type' => 'application/json'}, [result_json]]
+        [200, { 'Content-Type' => 'application/json'}, [result_json]]
       else
 
         # Otherwise give the HTML back
-        html = MiniProfiler.share_template.dup  
-        html.gsub!(/\{path\}/, @config.base_url_path)      
-        html.gsub!(/\{version\}/, MiniProfiler::VERSION)      
+        html = MiniProfiler.share_template.dup
+        html.gsub!(/\{path\}/, @config.base_url_path)
+        html.gsub!(/\{version\}/, MiniProfiler::VERSION)
         html.gsub!(/\{json\}/, result_json)
         html.gsub!(/\{includes\}/, get_profile_script(env))
         html.gsub!(/\{name\}/, page_struct['Name'])
         html.gsub!(/\{duration\}/, "%.1f" % page_struct.duration_ms)
-        
+
         [200, {'Content-Type' => 'text/html'}, [html]]
       end
 
-		end
+    end
 
-		def serve_html(env)
-			file_name = env['PATH_INFO'][(@config.base_url_path.length)..1000]
-			return serve_results(env) if file_name.eql?('results')
-			full_path = ::File.expand_path("../html/#{file_name}", ::File.dirname(__FILE__))
-			return [404, {}, ["Not found"]] unless ::File.exists? full_path
-			f = Rack::File.new nil
-			f.path = full_path
+    def serve_html(env)
+      file_name = env['PATH_INFO'][(@config.base_url_path.length)..1000]
+      return serve_results(env) if file_name.eql?('results')
+      full_path = ::File.expand_path("../html/#{file_name}", ::File.dirname(__FILE__))
+      return [404, {}, ["Not found"]] unless ::File.exists? full_path
+      f = Rack::File.new nil
+      f.path = full_path
 
-      begin 
+      begin
         f.cache_control = "max-age:86400"
         f.serving env
       rescue
-        # old versions of rack have a different api 
+        # old versions of rack have a different api
         status, headers, body = f.serving
         headers.merge! 'Cache-Control' => "max-age:86400"
         [status, headers, body]
       end
 
-		end
+    end
 
-    
+
     def current
       MiniProfiler.current
     end
@@ -191,7 +191,7 @@ module Rack
     end
 
 
-		def call(env)
+    def call(env)
 
       client_settings = ClientSettings.new(env)
 
@@ -201,20 +201,20 @@ module Rack
 
       skip_it = (@config.pre_authorize_cb && !@config.pre_authorize_cb.call(env)) ||
                 (@config.skip_paths && @config.skip_paths.any?{ |p| path[0,p.length] == p}) ||
-                query_string =~ /pp=skip/ 
-      
+                query_string =~ /pp=skip/
+
       has_profiling_cookie = client_settings.has_cookie?
-    
+
       if skip_it || (@config.authorization_mode == :whitelist && !has_profiling_cookie)
         status,headers,body = @app.call(env)
-        if !skip_it && @config.authorization_mode == :whitelist && !has_profiling_cookie && MiniProfiler.request_authorized? 
-          client_settings.write!(headers) 
+        if !skip_it && @config.authorization_mode == :whitelist && !has_profiling_cookie && MiniProfiler.request_authorized?
+          client_settings.write!(headers)
         end
         return [status,headers,body]
       end
 
       # handle all /mini-profiler requests here
-			return serve_html(env) if path.start_with? @config.base_url_path
+      return serve_html(env) if path.start_with? @config.base_url_path
 
       has_disable_cookie = client_settings.disable_profiling?
       # manual session disable / enable
@@ -271,8 +271,8 @@ module Rack
         skip_frames = 0
         backtraces = []
         t = Thread.current
-        
-        begin 
+
+        begin
           require 'stacktrace'
           skip_frames = stacktrace.length
         rescue LoadError
@@ -281,14 +281,14 @@ module Rack
 
         Thread.new {
           begin
-            i = 10000 # for sanity never grab more than 10k samples 
+            i = 10000 # for sanity never grab more than 10k samples
             while i > 0
               break if done_sampling
               i -= 1
               if stacktrace_installed
                 backtraces << t.stacktrace(0,-(1+skip_frames), StackFrame::Flags::METHOD | StackFrame::Flags::KLASS)
               else
-                backtraces << t.backtrace 
+                backtraces << t.backtrace
               end
               sleep 0.001
             end
@@ -298,11 +298,11 @@ module Rack
         }
       end
 
-			status, headers, body = nil
-      start = Time.now 
-      begin 
+      status, headers, body = nil
+      start = Time.now
+      begin
 
-        # Strip all the caching headers so we don't get 304s back 
+        # Strip all the caching headers so we don't get 304s back
         #  This solves a very annoying bug where rack mini profiler never shows up
         env['HTTP_IF_MODIFIED_SINCE'] = nil
         env['HTTP_IF_NONE_MATCH'] = nil
@@ -310,7 +310,7 @@ module Rack
         status,headers,body = @app.call(env)
         client_settings.write!(headers)
       ensure
-        if backtraces 
+        if backtraces
           done_sampling = true
           sleep 0.001 until quit_sampler
         end
@@ -320,7 +320,7 @@ module Rack
       if (config.authorization_mode == :whitelist && !MiniProfiler.request_authorized?)
         # this is non-obvious, don't kill the profiling cookie on errors or short requests
         # this ensures that stuff that never reaches the rails stack does not kill profiling
-        if status == 200 && ((Time.now - start) > 0.1) 
+        if status == 200 && ((Time.now - start) > 0.1)
           client_settings.discard_cookie!(headers)
         end
         skip_it = true
@@ -338,42 +338,42 @@ module Rack
         body.close if body.respond_to? :close
         return help(client_settings)
       end
-      
+
       page_struct = current.page_struct
       page_struct['User'] = user(env)
-			page_struct['Root'].record_time((Time.now - start) * 1000)
+      page_struct['Root'].record_time((Time.now - start) * 1000)
 
       if backtraces
         body.close if body.respond_to? :close
         return analyze(backtraces, page_struct)
       end
-      
+
 
       # no matter what it is, it should be unviewed, otherwise we will miss POST
       @storage.set_unviewed(page_struct['User'], page_struct['Id'])
-			@storage.save(page_struct)
-			
+      @storage.save(page_struct)
+
       # inject headers, script
-			if status == 200
+      if status == 200
 
         client_settings.write!(headers)
-        
+
         # mini profiler is meddling with stuff, we can not cache cause we will get incorrect data
         # Rack::ETag has already inserted some nonesense in the chain
         headers.delete('ETag')
         headers.delete('Date')
         headers['Cache-Control'] = 'must-revalidate, private, max-age=0'
 
-				# inject header
+        # inject header
         if headers.is_a? Hash
           headers['X-MiniProfiler-Ids'] = ids_json(env)
         end
 
-				# inject script
-				if current.inject_js \
-					&& headers.has_key?('Content-Type') \
-					&& !headers['Content-Type'].match(/text\/html/).nil? then
-					
+        # inject script
+        if current.inject_js \
+          && headers.has_key?('Content-Type') \
+          && !headers['Content-Type'].match(/text\/html/).nil? then
+
           response = Rack::Response.new([], status, headers)
           script = self.get_profile_script(env)
           if String === body
@@ -383,15 +383,15 @@ module Rack
           end
           body.close if body.respond_to? :close
           return response.finish
-				end
-			end
+        end
+      end
 
       client_settings.write!(headers)
-			[status, headers, body]
+      [status, headers, body]
     ensure
       # Make sure this always happens
       current = nil
-		end
+    end
 
     def inject(fragment, script)
       if fragment.match(/<\/body>/i)
@@ -423,12 +423,12 @@ module Rack
 
     def dump_env(env)
       headers = {'Content-Type' => 'text/plain'}
-      body = "Rack Environment\n---------------\n" 
+      body = "Rack Environment\n---------------\n"
       env.each do |k,v|
         body << "#{k}: #{v}\n"
       end
 
-      body << "\n\nEnvironment\n---------------\n" 
+      body << "\n\nEnvironment\n---------------\n"
       ENV.each do |k,v|
         body << "#{k}: #{v}\n"
       end
@@ -446,14 +446,14 @@ module Rack
   pp=skip : skip mini profiler for this request
   pp=no-backtrace #{"(*) " if client_settings.backtrace_none?}: don't collect stack traces from all the SQL executed (sticky, use pp=normal-backtrace to enable)
   pp=normal-backtrace #{"(*) " if client_settings.backtrace_default?}: collect stack traces from all the SQL executed and filter normally
-  pp=full-backtrace #{"(*) " if client_settings.backtrace_full?}: enable full backtraces for SQL executed (use pp=normal-backtrace to disable) 
+  pp=full-backtrace #{"(*) " if client_settings.backtrace_full?}: enable full backtraces for SQL executed (use pp=normal-backtrace to disable)
   pp=sample : sample stack traces and return a report isolating heavy usage (experimental works best with the stacktrace gem)
-  pp=disable : disable profiling for this session 
+  pp=disable : disable profiling for this session
   pp=enable : enable profiling for this session (if previously disabled)
   pp=profile-gc: perform gc profiling on this request, analyzes ObjectSpace generated by request (ruby 1.9.3 only)
   pp=profile-gc-time: perform built-in gc profiling on this request (ruby 1.9.3 only)
 "
-    
+
       client_settings.write!(headers)
       [200, headers, [body]]
     end
@@ -464,7 +464,7 @@ module Rack
 
       seen = {}
       fulldump = ""
-      traces.each do |trace| 
+      traces.each do |trace|
         fulldump << "\n\n"
         distinct = {}
         trace.each do |frame|
@@ -484,7 +484,7 @@ module Rack
           body << "#{name} x #{count}\n"
         end
       end
-      
+
       body << "\n\n\nRaw traces \n"
       body << fulldump
 
@@ -503,40 +503,40 @@ module Rack
       ids.join(",")
     end
 
-		# get_profile_script returns script to be injected inside current html page
-		# By default, profile_script is appended to the end of all html requests automatically.
-		# Calling get_profile_script cancels automatic append for the current page
-		# Use it when:
-		# * you have disabled auto append behaviour throught :auto_inject => false flag
-		# * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
-		def get_profile_script(env)
-			ids = ids_comma_separated(env)
-			path = @config.base_url_path
-			version = MiniProfiler::VERSION
-			position = @config.position
-			showTrivial = false
-			showChildren = false
-			maxTracesToShow = 10
-			showControls = false
-			currentId = current.page_struct["Id"]
-			authorized = true
-			# TODO : cache this snippet 
-			script = IO.read(::File.expand_path('../html/profile_handler.js', ::File.dirname(__FILE__)))
-			# replace the variables
-			[:ids, :path, :version, :position, :showTrivial, :showChildren, :maxTracesToShow, :showControls, :currentId, :authorized].each do |v|
-				regex = Regexp.new("\\{#{v.to_s}\\}")
-				script.gsub!(regex, eval(v.to_s).to_s)
-			end
-			current.inject_js = false
-			script
-		end
+    # get_profile_script returns script to be injected inside current html page
+    # By default, profile_script is appended to the end of all html requests automatically.
+    # Calling get_profile_script cancels automatic append for the current page
+    # Use it when:
+    # * you have disabled auto append behaviour throught :auto_inject => false flag
+    # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
+    def get_profile_script(env)
+      ids = ids_comma_separated(env)
+      path = @config.base_url_path
+      version = MiniProfiler::VERSION
+      position = @config.position
+      showTrivial = false
+      showChildren = false
+      maxTracesToShow = 10
+      showControls = false
+      currentId = current.page_struct["Id"]
+      authorized = true
+      # TODO : cache this snippet
+      script = IO.read(::File.expand_path('../html/profile_handler.js', ::File.dirname(__FILE__)))
+      # replace the variables
+      [:ids, :path, :version, :position, :showTrivial, :showChildren, :maxTracesToShow, :showControls, :currentId, :authorized].each do |v|
+        regex = Regexp.new("\\{#{v.to_s}\\}")
+        script.gsub!(regex, eval(v.to_s).to_s)
+      end
+      current.inject_js = false
+      script
+    end
 
-		# cancels automatic injection of profile script for the current page
-		def cancel_auto_inject(env)
-		  current.inject_js = false
-		end
+    # cancels automatic injection of profile script for the current page
+    def cancel_auto_inject(env)
+      current.inject_js = false
+    end
 
-	end
+  end
 
 end
 

--- a/Ruby/lib/mini_profiler/profiling_methods.rb
+++ b/Ruby/lib/mini_profiler/profiling_methods.rb
@@ -1,12 +1,12 @@
 module Rack
   class MiniProfiler
-    module ProfilingMethods 
-     
-		  def record_sql(query, elapsed_ms)
+    module ProfilingMethods
+
+      def record_sql(query, elapsed_ms)
         c = current
         return unless c
-			  c.current_timer.add_sql(query, elapsed_ms, c.page_struct, c.skip_backtrace, c.full_backtrace) if (c && c.current_timer)
-		  end
+        c.current_timer.add_sql(query, elapsed_ms, c.page_struct, c.skip_backtrace, c.full_backtrace) if (c && c.current_timer)
+      end
 
       def start_step(name)
         if current
@@ -29,8 +29,8 @@ module Rack
         if current
           parent_timer = current.current_timer
           result = nil
-          current.current_timer = current_timer = current.current_timer.add_child(name) 
-          begin 
+          current.current_timer = current_timer = current.current_timer.add_child(name)
+          begin
             result = yield if block_given?
           ensure
             current_timer.record_time
@@ -47,7 +47,7 @@ module Rack
 
         with_profiling = ("#{clean}_with_mini_profiler").intern
         without_profiling = ("#{clean}_without_mini_profiler").intern
-        
+
         if klass.send :method_defined?, with_profiling
           klass.send :alias_method, method, without_profiling
           klass.send :remove_method, with_profiling
@@ -61,16 +61,16 @@ module Rack
 
         with_profiling =  ("#{clean}_with_mini_profiler").intern
         without_profiling = ("#{clean}_without_mini_profiler").intern
-        
+
         if klass.send :method_defined?, with_profiling
           return # dont double profile
         end
-          
+
         klass.send :alias_method, without_profiling, method
         klass.send :define_method, with_profiling do |*args, &orig|
           return self.send without_profiling, *args, &orig unless Rack::MiniProfiler.current
 
-          name = default_name 
+          name = default_name
           if blk
             name =
               if respond_to?(:instance_exec)
@@ -85,14 +85,14 @@ module Rack
           page_struct = Rack::MiniProfiler.current.page_struct
           result = nil
 
-          Rack::MiniProfiler.current.current_timer = current_timer = parent_timer.add_child(name) 
-          begin 
+          Rack::MiniProfiler.current.current_timer = current_timer = parent_timer.add_child(name)
+          begin
             result = self.send without_profiling, *args, &orig
           ensure
             current_timer.record_time
             Rack::MiniProfiler.current.current_timer = parent_timer
-          end 
-          result 
+          end
+          result
         end
         klass.send :alias_method, method, with_profiling
       end

--- a/Ruby/lib/mini_profiler/storage/file_store.rb
+++ b/Ruby/lib/mini_profiler/storage/file_store.rb
@@ -9,7 +9,7 @@ module Rack
         end
 
         def [](key)
-          begin 
+          begin
             data = ::File.open(path(key),"rb") {|f| f.read}
             return Marshal.load data
           rescue => e
@@ -28,7 +28,7 @@ module Rack
       end
 
       EXPIRE_TIMER_CACHE = 3600 * 24
-     
+
       def initialize(args)
         @path = args[:path]
         raise ArgumentError.new :path unless @path
@@ -39,26 +39,26 @@ module Rack
 
         me = self
         Thread.new do
-          begin 
+          begin
             while true do
               # TODO: a sane retry count before bailing
               me.cleanup_cache
               sleep(3600)
             end
           rescue
-            # don't crash the thread, we can clean up next time 
+            # don't crash the thread, we can clean up next time
           end
         end
       end
 
       def save(page_struct)
-		  	@timer_struct_lock.synchronize {
-			  	@timer_struct_cache[page_struct['Id']] = page_struct
-			  }
+        @timer_struct_lock.synchronize {
+          @timer_struct_cache[page_struct['Id']] = page_struct
+        }
       end
 
       def load(id)
-			  @timer_struct_lock.synchronize {
+        @timer_struct_lock.synchronize {
           @timer_struct_cache[id]
         }
       end
@@ -87,7 +87,7 @@ module Rack
           @user_view_cache[user]
         }
       end
-      
+
       def cleanup_cache
         files = Dir.entries(@path)
         @timer_struct_lock.synchronize {
@@ -103,7 +103,7 @@ module Rack
           end
         }
       end
-    
+
     end
   end
 end

--- a/Ruby/lib/mini_profiler/storage/memory_store.rb
+++ b/Ruby/lib/mini_profiler/storage/memory_store.rb
@@ -3,7 +3,7 @@ module Rack
     class MemoryStore < AbstractStore
 
       EXPIRE_TIMER_CACHE = 3600 * 24
-     
+
       def initialize(args)
         @timer_struct_lock = Mutex.new
         @timer_struct_cache = {}
@@ -21,13 +21,13 @@ module Rack
       end
 
       def save(page_struct)
-		  	@timer_struct_lock.synchronize {
-			  	@timer_struct_cache[page_struct['Id']] = page_struct
-			  }
+        @timer_struct_lock.synchronize {
+          @timer_struct_cache[page_struct['Id']] = page_struct
+        }
       end
 
       def load(id)
-			  @timer_struct_lock.synchronize {
+        @timer_struct_lock.synchronize {
           @timer_struct_cache[id]
         }
       end
@@ -51,7 +51,7 @@ module Rack
           @user_view_cache[user]
         }
       end
-      
+
       def cleanup_cache
         expire_older_than = ((Time.now.to_f - MiniProfiler::MemoryStore::EXPIRE_TIMER_CACHE) * 1000).to_i
         @timer_struct_lock.synchronize {

--- a/Ruby/lib/patches/sql_patches.rb
+++ b/Ruby/lib/patches/sql_patches.rb
@@ -8,32 +8,32 @@ class SqlPatches
     @patched = val
   end
 
-	def self.class_exists?(name)
-		eval(name + ".class").to_s.eql?('Class')
-	rescue NameError
-		false
-	end
-	
+  def self.class_exists?(name)
+    eval(name + ".class").to_s.eql?('Class')
+  rescue NameError
+    false
+  end
+
   def self.module_exists?(name)
-		eval(name + ".class").to_s.eql?('Module')
-	rescue NameError
-		false
-	end
+    eval(name + ".class").to_s.eql?('Module')
+  rescue NameError
+    false
+  end
 end
 
 # The best kind of instrumentation is in the actual db provider, however we don't want to double instrument
 if SqlPatches.class_exists? "Mysql2::Client"
-  
+
   class Mysql2::Result
     alias_method :each_without_profiling, :each
     def each(*args, &blk)
       return each_without_profiling(*args, &blk) unless @miniprofiler_sql_id
 
       start = Time.now
-      result = each_without_profiling(*args,&blk) 
+      result = each_without_profiling(*args,&blk)
       elapsed_time = ((Time.now - start).to_f * 1000).round(1)
 
-      @miniprofiler_sql_id.report_reader_duration(elapsed_time) 
+      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
       result
     end
   end
@@ -53,14 +53,14 @@ if SqlPatches.class_exists? "Mysql2::Client"
 
     end
   end
-    
+
   SqlPatches.patched = true
 end
 
 
-# PG patches, keep in mind exec and async_exec have a exec{|r| } semantics that is yet to be implemented 
+# PG patches, keep in mind exec and async_exec have a exec{|r| } semantics that is yet to be implemented
 if SqlPatches.class_exists? "PG::Result"
-  
+
   class PG::Result
     alias_method :each_without_profiling, :each
     alias_method :values_without_profiling, :values
@@ -69,10 +69,10 @@ if SqlPatches.class_exists? "PG::Result"
       return values_without_profiling(*args, &blk) unless @miniprofiler_sql_id
 
       start = Time.now
-      result = values_without_profiling(*args,&blk) 
+      result = values_without_profiling(*args,&blk)
       elapsed_time = ((Time.now - start).to_f * 1000).round(1)
 
-      @miniprofiler_sql_id.report_reader_duration(elapsed_time) 
+      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
       result
     end
 
@@ -80,10 +80,10 @@ if SqlPatches.class_exists? "PG::Result"
       return each_without_profiling(*args, &blk) unless @miniprofiler_sql_id
 
       start = Time.now
-      result = each_without_profiling(*args,&blk) 
+      result = each_without_profiling(*args,&blk)
       elapsed_time = ((Time.now - start).to_f * 1000).round(1)
 
-      @miniprofiler_sql_id.report_reader_duration(elapsed_time) 
+      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
       result
     end
   end
@@ -96,9 +96,9 @@ if SqlPatches.class_exists? "PG::Result"
     alias_method :prepare_without_profiling, :prepare
 
     def prepare(*args,&blk)
-      # we have no choice but to do this here, 
-      # if we do the check for profiling first, our cache may miss critical stuff  
-      
+      # we have no choice but to do this here,
+      # if we do the check for profiling first, our cache may miss critical stuff
+
       @prepare_map ||= {}
       @prepare_map[args[0]] = args[1]
       # dont leak more than 10k ever
@@ -107,7 +107,7 @@ if SqlPatches.class_exists? "PG::Result"
       current = ::Rack::MiniProfiler.current
       return prepare_without_profiling(*args,&blk) unless current
 
-      prepare_without_profiling(*args,&blk) 
+      prepare_without_profiling(*args,&blk)
     end
 
     def exec(*args,&blk)
@@ -135,7 +135,7 @@ if SqlPatches.class_exists? "PG::Result"
 
       result
     end
-    
+
     def send_query_prepared(*args,&blk)
       current = ::Rack::MiniProfiler.current
       return send_query_prepared_without_profiling(*args,&blk) unless current
@@ -149,7 +149,7 @@ if SqlPatches.class_exists? "PG::Result"
 
       result
     end
-    
+
     def async_exec(*args,&blk)
       current = ::Rack::MiniProfiler.current
       return exec_without_profiling(*args,&blk) unless current
@@ -161,10 +161,10 @@ if SqlPatches.class_exists? "PG::Result"
 
       result
     end
-    
+
     alias_method :query, :exec
   end
-    
+
   SqlPatches.patched = true
 end
 
@@ -213,15 +213,15 @@ end
 
 # Fallback for sequel
 if SqlPatches.class_exists?("Sequel::Database") && !SqlPatches.patched?
-	module Sequel
-		class Database
-			alias_method :log_duration_original, :log_duration
-			def log_duration(duration, message)
-				::Rack::MiniProfiler.record_sql(message, duration)
-				log_duration_original(duration, message)
-			end
-		end
-	end
+  module Sequel
+    class Database
+      alias_method :log_duration_original, :log_duration
+      def log_duration(duration, message)
+        ::Rack::MiniProfiler.record_sql(message, duration)
+        log_duration_original(duration, message)
+      end
+    end
+  end
 end
 
 
@@ -229,7 +229,7 @@ end
 ## fallback for alls sorts of weird dbs
 if SqlPatches.module_exists?('ActiveRecord') && !SqlPatches.patched?
   module Rack
-    class MiniProfiler  
+    class MiniProfiler
       module ActiveRecordInstrumentation
         def self.included(instrumented_class)
           instrumented_class.class_eval do
@@ -248,7 +248,7 @@ if SqlPatches.module_exists?('ActiveRecord') && !SqlPatches.patched?
           sql, name, binds = args
           t0 = Time.now
           rval = log_without_miniprofiler(*args, &block)
-          
+
           # Don't log schema queries if the option is set
           return rval if Rack::MiniProfiler.config.skip_schema_queries and name =~ /SCHEMA/
 
@@ -259,7 +259,7 @@ if SqlPatches.module_exists?('ActiveRecord') && !SqlPatches.patched?
       end
     end
 
-    def self.insert_instrumentation 
+    def self.insert_instrumentation
       ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
         include ::Rack::MiniProfiler::ActiveRecordInstrumentation
       end

--- a/Ruby/test_old/config.ru
+++ b/Ruby/test_old/config.ru
@@ -8,31 +8,30 @@ require 'logger'
 use Rack::MiniProfiler
 options = {}
 options[:logger] = Logger.new(STDOUT)
-DB = Sequel.connect("mysql2://sveg:svegsveg@localhost/sveg_development",
-	options)
+DB = Sequel.connect("mysql2://sveg:svegsveg@localhost/sveg_development", options)
 
 app = proc do |env|
-	sleep(0.1)
-	env['profiler.mini'].benchmark(env, "sleep0.2") do
-		sleep(0.2)
-	end
-	env['profiler.mini'].benchmark(env, 'sleep0.1') do
-		sleep(0.1)
-		env['profiler.mini'].benchmark(env, 'sleep0.01') do
-			sleep(0.01)
-			env['profiler.mini'].benchmark(env, 'sleep0.001') do
-				sleep(0.001)
-				DB.fetch('SHOW TABLES') do |row|
-					puts row
-				end
-			end
-			env['profiler.mini'].benchmark(env, 'litl sql') do
-				DB.fetch('select * from auth_logins') do |row|
-					puts row
-				end
-			end
-		end
-	end
+  sleep(0.1)
+  env['profiler.mini'].benchmark(env, "sleep0.2") do
+    sleep(0.2)
+  end
+  env['profiler.mini'].benchmark(env, 'sleep0.1') do
+    sleep(0.1)
+    env['profiler.mini'].benchmark(env, 'sleep0.01') do
+      sleep(0.01)
+      env['profiler.mini'].benchmark(env, 'sleep0.001') do
+        sleep(0.001)
+        DB.fetch('SHOW TABLES') do |row|
+          puts row
+        end
+      end
+      env['profiler.mini'].benchmark(env, 'litl sql') do
+        DB.fetch('select * from auth_logins') do |row|
+          puts row
+        end
+      end
+    end
+  end
   [ 200, {'Content-Type' => 'text/html'}, ["<h1>This is Rack::MiniProfiler test"] ]
 end
 

--- a/StackExchange.Profiling/UI/includes.less
+++ b/StackExchange.Profiling/UI/includes.less
@@ -49,7 +49,7 @@
 // styles shared between popup view and full view
 .profiler-result 
 {
- 
+
     .profiler-toggle-duration-with-children
     {
         float: right;
@@ -192,15 +192,15 @@
             text-align:right;
             margin-bottom:5px;
         }
-        
+
         .profiler-gap-info, .profiler-gap-info td { background-color: #ccc;}
         .profiler-gap-info  {
             .profiler-unit {color: #777;}
             .profiler-info {text-align: right}
             &.profiler-trivial-gaps {display: none}
-         }
-         
-         .profiler-trivial-gap-container { text-align: center;}
+        }
+
+        .profiler-trivial-gap-container { text-align: center;}
 
         // prettify colors
         .str{color:maroon}
@@ -290,24 +290,24 @@
         }
     }
 
-	.profiler-controls {
-		display: block;
-		font-size:12px;
-		font-family: @codeFonts;
-		cursor:default;
-		text-align: center;
+    .profiler-controls {
+        display: block;
+        font-size:12px;
+        font-family: @codeFonts;
+        cursor:default;
+        text-align: center;
 
-		span {
-			border-right: 1px solid @mutedColor;
-			padding-right: 5px;
-			margin-right: 5px;
-			cursor:pointer;
-		}
+        span {
+            border-right: 1px solid @mutedColor;
+            padding-right: 5px;
+            margin-right: 5px;
+            cursor:pointer;
+        }
 
-		span:last-child {
-			border-right: none;
-		}		
-	}
+        span:last-child {
+            border-right: none;
+        }
+    }
 
     .profiler-popup {
         display:none;
@@ -370,19 +370,19 @@
         }
     }
 
-	&.profiler-min .profiler-result {
-		display: none;
-	}
+    &.profiler-min .profiler-result {
+        display: none;
+    }
 
-	&.profiler-min .profiler-controls span {
-		display: none;
-	}
+    &.profiler-min .profiler-controls span {
+        display: none;
+    }
 
-	&.profiler-min .profiler-controls .profiler-min-max {
-		border-right: none;
-		padding: 0px;
-		margin: 0px;
-	}
+    &.profiler-min .profiler-controls .profiler-min-max {
+        border-right: none;
+        padding: 0px;
+        margin: 0px;
+    }
 }
 
 // popup results' queries will be displayed in front of this


### PR DESCRIPTION
There were quite some files in MiniProfiler Ruby that mixed tabs and spaces for indenting
which have been fixed to use spaces consistently.
I've also removed redundant whitespace for those files.

One file it outside the Ruby directory because it's symlinked.
