### PR TITLE
Update redis_store.rb to reuse single connection 

### DIFF
--- a/Ruby/lib/mini_profiler/storage/redis_store.rb
+++ b/Ruby/lib/mini_profiler/storage/redis_store.rb
@@ -38,7 +38,7 @@ module Rack
       def redis
         return @redis_connection if @redis_connection
         require 'redis' unless defined? Redis
-        Redis.new @args
+        @redis ||= Redis.new @args
       end
 
     end


### PR DESCRIPTION
Each time the redis method got hit, it would spawn a new redis connection. This simple fix reuses a single connection per process. Should stop connection leaks and redundant connections to the redis provider. 
