### PR TITLE
Fixes #121 (tmp/miniprofiler never gets cleaned up)

### DIFF
--- a/Ruby/lib/mini_profiler/storage/file_store.rb
+++ b/Ruby/lib/mini_profiler/storage/file_store.rb
@@ -93,13 +93,13 @@ module Rack
         @timer_struct_lock.synchronize {
           files.each do |f|
             f = @path + '/' + f
-            File.delete f if f =~ /^mp_timers/ and (Time.now - File.mtime(f)) > EXPIRE_TIMER_CACHE
+            ::File.delete f if ::File.basename(f) =~ /^mp_timers/ and (Time.now - ::File.mtime(f)) > EXPIRE_TIMER_CACHE
           end
         }
         @user_view_lock.synchronize {
           files.each do |f|
             f = @path + '/' + f
-            File.delete f if f =~ /^mp_views/ and (Time.now - File.mtime(f)) > EXPIRE_TIMER_CACHE
+            ::File.delete f if ::File.basename(f) =~ /^mp_views/ and (Time.now - ::File.mtime(f)) > EXPIRE_TIMER_CACHE
           end
         }
       end


### PR DESCRIPTION
Fixes issue with `tmp/miniprofiler` directory filling up with files.

`FileStore` was throwing exceptions calling `File.mtime` (File was resolving to `Rack::File` instead of `::File`).  Also, the regex was comparing against the full file path instead of its name.
