### PR TITLE
Adds ':expires_in' option for all storage engines

### DIFF
--- a/Ruby/lib/mini_profiler/storage/file_store.rb
+++ b/Ruby/lib/mini_profiler/storage/file_store.rb
@@ -27,10 +27,12 @@ module Rack
         end
       end
 
-      EXPIRE_TIMER_CACHE = 3600 * 24
+      EXPIRES_IN = 3600 * 24
 
-      def initialize(args)
+      def initialize(args = nil)
+        args ||= {}
         @path = args[:path]
+        @expires_in = args[:expires_in] || EXPIRES_IN
         raise ArgumentError.new :path unless @path
         @timer_struct_cache = FileCache.new(@path, "mp_timers")
         @timer_struct_lock = Mutex.new

--- a/Ruby/lib/mini_profiler/storage/memory_store.rb
+++ b/Ruby/lib/mini_profiler/storage/memory_store.rb
@@ -2,9 +2,11 @@ module Rack
   class MiniProfiler
     class MemoryStore < AbstractStore
 
-      EXPIRE_TIMER_CACHE = 3600 * 24
+      EXPIRES_IN = 3600 * 24
 
-      def initialize(args)
+      def initialize(args = nil)
+        args ||= {}
+        @expires_in = args[:expires_in] || EXPIRES_IN
         @timer_struct_lock = Mutex.new
         @timer_struct_cache = {}
         @user_view_lock = Mutex.new
@@ -53,7 +55,7 @@ module Rack
       end
 
       def cleanup_cache
-        expire_older_than = ((Time.now.to_f - MiniProfiler::MemoryStore::EXPIRE_TIMER_CACHE) * 1000).to_i
+        expire_older_than = ((Time.now.to_f - @expires_in) * 1000).to_i
         @timer_struct_lock.synchronize {
           @timer_struct_cache.delete_if { |k, v| v['Started'] < expire_older_than }
         }

--- a/Ruby/lib/mini_profiler/storage/redis_store.rb
+++ b/Ruby/lib/mini_profiler/storage/redis_store.rb
@@ -2,16 +2,17 @@ module Rack
   class MiniProfiler
     class RedisStore < AbstractStore
 
-      EXPIRE_SECONDS = 60 * 60 * 24
+      EXPIRES_IN = 60 * 60 * 24
      
-      def initialize(args)
+      def initialize(args = nil)
         @args = args || {}
         @prefix = @args.delete(:prefix) || 'MPRedisStore'
         @redis_connection = @args.delete(:connection)
+        @expires_in = @args.delete(:expires_in) || EXPIRES_IN
       end
 
       def save(page_struct)
-        redis.setex "#{@prefix}#{page_struct['Id']}", EXPIRE_SECONDS, Marshal::dump(page_struct) 
+        redis.setex "#{@prefix}#{page_struct['Id']}", @expires_in, Marshal::dump(page_struct) 
       end
 
       def load(id)

--- a/Ruby/spec/components/memory_store_spec.rb
+++ b/Ruby/spec/components/memory_store_spec.rb
@@ -7,7 +7,7 @@ describe Rack::MiniProfiler::MemoryStore do
   context 'page struct' do
 
     before do
-      @store = Rack::MiniProfiler::MemoryStore.new nil
+      @store = Rack::MiniProfiler::MemoryStore.new
     end
 
     describe 'storage' do


### PR DESCRIPTION
Adds `:expires_in` option to all storage subclasses.  `:xpires_in` controls how long MiniProfiler will cache results (defaults is still 24 hours).

Example:

``` ruby
Rack::MiniProfiler.config.storage_options = { :expires_in => 5.minutes }
Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
```

Also fixes #103 (MemcacheStore has wrong defaults for Dalli client).

**WARNING**: this is a breaking change for anyone initializing MemcacheStore manually, because the signature for the initializer changed (to make it consistent with other storage subclasses).

``` ruby
# old way: manually initialize store instance
Rack::MiniProfiler.config.storage_instance = Rack::MiniProfiler::MemcacheStore.new(Dalli::Client.new)

# new way
Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemcacheStore
```
