### PR TITLE
Update javascript references in flamegraph.html to be protocoless.

### DIFF
--- a/StackExchange.Profiling/UI/flamegraph.html
+++ b/StackExchange.Profiling/UI/flamegraph.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.0.8/d3.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.0.8/d3.min.js"></script>
 <!-- <script src="http://cdnjs.cloudflare.com/ajax/libs/sugar/1.3.8/sugar.min.js"></script> -->
 <meta charset=utf-8 />
 <title>Flame Graph of Page</title>


### PR DESCRIPTION
Chrome is blocking flamegraph profiling in production because we require https. This minor change makes the javascript references protocoless. 

I also changed the jquery reference to use Cloudflare's CDN because the jQuery CDN doesn't appear to have a valid certificate for SSL.
