### PR TITLE
Support SCRIPT_NAME in MiniProfiler

### DIFF
--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -123,7 +123,7 @@ module Rack
 
         # Otherwise give the HTML back
         html = MiniProfiler.share_template.dup
-        html.gsub!(/\{path\}/, @config.base_url_path)
+        html.gsub!(/\{path\}/, "#{env['SCRIPT_NAME']}#{@config.base_url_path}")
         html.gsub!(/\{version\}/, MiniProfiler::VERSION)
         html.gsub!(/\{json\}/, result_json)
         html.gsub!(/\{includes\}/, get_profile_script(env))
@@ -511,7 +511,7 @@ module Rack
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
       ids = ids_comma_separated(env)
-      path = @config.base_url_path
+      path = "#{env['SCRIPT_NAME']}#{@config.base_url_path}"
       version = MiniProfiler::VERSION
       position = @config.position
       showTrivial = false

--- a/Ruby/spec/integration/mini_profiler_spec.rb
+++ b/Ruby/spec/integration/mini_profiler_spec.rb
@@ -111,6 +111,18 @@ describe Rack::MiniProfiler do
   end
 
 
+  describe 'with a SCRIPT_NAME' do
+
+    before do
+      get '/html', nil, 'SCRIPT_NAME' => '/test'
+    end
+
+    it 'has the JS in the body with the correct path' do
+      last_response.body.include?('/test/mini-profiler-resources/includes.js').should be_true
+    end
+
+  end
+
   describe 'configuration' do
     it "doesn't add MiniProfiler if the callback fails" do
       Rack::MiniProfiler.config.pre_authorize_cb = lambda {|env| false }


### PR DESCRIPTION
Currently MiniProfiler ignores SCRIPT_NAME in Rack, which prevents apps running at relative paths (like '/myapp') from serving the JS or responding to the core requests.  This pull prefixes @config.base_url_path with env['SCRIPT_NAME'] when serving the JS append and when serving results - serving links to '/myapp/mini-profiler-resources/...'.

Commit includes a failing test.
