### PR TITLE
Bug Fix - rack + rack-cache throw an error sometimes because HTTP_IF_NONE_MATCH is nil

### DIFF
--- a/Ruby/lib/mini_profiler/profiler.rb
+++ b/Ruby/lib/mini_profiler/profiler.rb
@@ -272,8 +272,8 @@ module Rack
 
         # Strip all the caching headers so we don't get 304s back
         #  This solves a very annoying bug where rack mini profiler never shows up
-        env['HTTP_IF_MODIFIED_SINCE'] = nil
-        env['HTTP_IF_NONE_MATCH'] = nil
+        env['HTTP_IF_MODIFIED_SINCE'] = ''
+        env['HTTP_IF_NONE_MATCH'] = ''
 
         status,headers,body = @app.call(env)
         client_settings.write!(headers)


### PR DESCRIPTION
Making cache headers empty strings rather than nil.

The following is an explanation for this fix:

1) Rack-Cache freezes the environment variable.
 https://github.com/rtomayko/rack-cache/blob/1.2/lib/rack/cache/context.rb#L61

2) Rack picks it up and looks for 'HTTP_IF_NONE_MATCH. 
https://github.com/rtomayko/rack-cache/blob/1.1/lib/rack/cache/context.rb#L111

3) Since MiniProfiler sets HTTP_IF_NONE_MATCH to nil, the value returned is nil. But, rack thinks the environment variables are not loaded.
https://github.com/jruby/jruby-rack/blob/master/src/main/ruby/rack/handler/servlet/default_env.rb#L87

4) A load results in modifying the env variable (which is frozen)
https://github.com/jruby/jruby-rack/blob/master/src/main/ruby/rack/handler/servlet/default_env.rb#L163

5) Runtime error because we are modifying a frozen object.

Here is the traceback below:

org.jruby.exceptions.RaiseException: (TypeError) can't modify frozen hash
    at org.jruby.RubyHash.[]=(org/jruby/RubyHash.java:897)
    at Rack::Handler::Servlet::DefaultEnv.load_header(file:/opt/ruby/gems/1.8/gems/jruby-rack-1.1.13.2/lib/jruby-rack-1.1.13.2.jar!/rack/handler/servlet/default_env.rb:163)
    at Rack::Handler::Servlet::DefaultEnv.load_env_key(file:/opt/ruby/gems/1.8/gems/jruby-rack-1.1.13.2/lib/jruby-rack-1.1.13.2.jar!/rack/handler/servlet/default_env.rb:149)
    at Rack::Handler::Servlet::DefaultEnv.[](file:/opt/ruby/gems/1.8/gems/jruby-rack-1.1.13.2/lib/jruby-rack-1.1.13.2.jar!/rack/handler/servlet/default_env.rb:87)
    at Rack::Cache::Context.not_modified?(/opt/ruby/gems/1.8/gems/rack-cache-1.2/lib/rack/cache/context.rb:115)
    at Rack::Cache::Context.call!(/opt/ruby/gems/1.8/gems/rack-cache-1.2/lib/rack/cache/context.rb:86)
    at Rack::Cache::Context.call(/opt/ruby/gems/1.8/gems/rack-cache-1.2/lib/rack/cache/context.rb:51)
    at Rack::MiniProfiler.call(/opt/ruby/gems/1.8/gems/rack-mini-profiler-0.1.26/Ruby/lib/mini_profiler/profiler.rb:278)
    at Rack::MiniProfiler.call(/opt/ruby/gems/1.8/gems/rack-mini-profiler-0.1.26/Ruby/lib/mini_profiler/profiler.rb:271)
    at Rails::Engine.call(/opt/ruby/gems/1.8/gems/railties-3.2.13/lib/rails/engine.rb:479)
    at Rails::Application.call(/opt/ruby/gems/1.8/gems/railties-3.2.13/lib/rails/application.rb:223)
    at Rack::Handler::Servlet.call(file:/opt/ruby/gems/1.8/gems/jruby-rack-1.1.13.2/lib/jruby-rack-1.1.13.2.jar!/rack/handler/servlet.rb:22)
