### PR TITLE
Loads jquery 2.0.0 instead of failing back to 1.7.1

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -657,7 +657,7 @@ var MiniProfiler = (function () {
             if (typeof(jQuery) == 'function') {
                 var jQueryVersion = jQuery.fn.jquery.split('.');
             }
-            if (jQueryVersion && parseInt(jQueryVersion[0]) < 2 && parseInt(jQueryVersion[1]) >= 7) {
+            if (jQueryVersion && (parseInt(jQueryVersion[0]) == 2) || (parseInt(jQueryVersion[0]) < 2 && parseInt(jQueryVersion[1]) >= 7)) {
                 MiniProfiler.jQuery = $ = jQuery;
                 $(deferInit);
             } else {


### PR DESCRIPTION
Fixes an issue with jquery.hotkeys where any keystroke would cause the profiler UI to toggle.  When 2.0.0 is used, or any version before 1.7, jquery.hotkeys will hook up special events to the wrong version of jquery (not the one miniprofiler loads: 1.7.1).  This change fixes it only for 2.0.0.
