### PR TITLE
Add backtrace_threshold_ms to omit backtrace collection for queries that...

### DIFF
--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -113,6 +113,9 @@ You can set configuration options using the configuration accessor on Rack::Mini
 Rack::MiniProfiler.config.position = 'right'
 # Have Mini Profiler start in hidden mode - display with short cut (defaulted to 'Alt+P')
 Rack::MiniProfiler.config.start_hidden = true
+# Don't collect backtraces on SQL queries that take less than 5 ms to execute
+# (necessary on Rubies earlier than 2.0)
+Rack::MiniProfiler.config.backtrace_threshold_ms = 5
 ```
 
 
@@ -157,6 +160,7 @@ end
 * backtrace_filter - a regex you can use to filter out unwanted lines from the backtraces
 * toggle_shortcut (default Alt+P) - a jquery.hotkeys.js-style keyboard shortcut, used to toggle the mini_profiler's visibility. See http://code.google.com/p/js-hotkeys/ for more info.
 * start_hidden (default false) - Whether or not you want the mini_profiler to be visible when loading a page
+* backtrace_threshold_ms (default zero) - Minimum SQL query elapsed time before a backtrace is recorded. Backtrace recording can take a couple of milliseconds on rubies earlier than 2.0, impacting performance for very small queries.
 
 ## Special query strings 
 

--- a/Ruby/lib/mini_profiler/config.rb
+++ b/Ruby/lib/mini_profiler/config.rb
@@ -15,7 +15,7 @@ module Rack
     attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
         :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries, 
         :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode,
-        :toggle_shortcut, :start_hidden
+        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms
 
     # Deprecated options
     attr_accessor :use_existing_jquery
@@ -36,6 +36,7 @@ module Rack
           @authorization_mode = :allow_all
           @toggle_shortcut = 'Alt+P'
           @start_hidden = false
+          @backtrace_threshold_ms = 0
           self
         }
       end

--- a/Ruby/lib/mini_profiler/sql_timer_struct.rb
+++ b/Ruby/lib/mini_profiler/sql_timer_struct.rb
@@ -8,7 +8,7 @@ module Rack
       def initialize(query, duration_ms, page, parent, skip_backtrace = false, full_backtrace = false)
 
         stack_trace = nil 
-        unless skip_backtrace 
+        unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
           # Allow us to filter the stack trace
           stack_trace = ""
            # Clean up the stack trace if there are options to do so

--- a/Ruby/spec/components/sql_timer_struct_spec.rb
+++ b/Ruby/spec/components/sql_timer_struct_spec.rb
@@ -64,7 +64,17 @@ describe Rack::MiniProfiler::SqlTimerStruct do
       sql['StackTraceSnippet'].should_not match /rspec/
     end
 
+    it "should omit the backtrace if the query takes less than the threshold time" do
+      Rack::MiniProfiler.config.backtrace_threshold_ms = 100
+      sql = Rack::MiniProfiler::SqlTimerStruct.new("SELECT * FROM users", 50, Rack::MiniProfiler::PageTimerStruct.new({}), nil)
+      sql['StackTraceSnippet'].should be nil
+    end
 
+    it "should not omit the backtrace if the query takes more than the threshold time" do
+      Rack::MiniProfiler.config.backtrace_threshold_ms = 100
+      sql = Rack::MiniProfiler::SqlTimerStruct.new("SELECT * FROM users", 200, Rack::MiniProfiler::PageTimerStruct.new({}), nil)
+      sql['StackTraceSnippet'].should_not be nil
+    end
   end
 
 end


### PR DESCRIPTION
... take less than a set time to complete.

See issue #156
