### PR TITLE
Disable jQuery global AJAX handlers

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -126,6 +126,7 @@ var MiniProfiler = (function () {
                     url: options.path + 'results',
                     data: { id: id, clientPerformance: clientPerformance, clientProbes: clientProbes, popup: 1 },
                     dataType: 'json',
+                    global: false,
                     type: 'POST',
                     success: function (json) {
                         fetchedIds.push(id);


### PR DESCRIPTION
jQuery allows to define global AJAX handlers which will get fired for every request made with `$.ajax` or such. See documentation on [jQuery API website](http://api.jquery.com/category/ajax/global-ajax-event-handlers/).

I am currently profiling an app that defines some behaviors for the `ajaxStart` & `ajaxStop` handlers. The 2 handlers are triggered when MiniProfiler fetches results. I do not really care about these behavior end would like MiniProfiler to not trigger them. jQuery offers a boolean called `global` which can be used as an option for `$.ajax` to disable the global handlers. This pull request sets `global` to `false` for the MiniProfiler call that fetches the results and this resolves the problem for me. I thought I'll share this as others might encounter the situation.

BTW, thank you for building this tool, it is so awesome & useful. If you guys are ever in SF, I'll owe you a beer or two :smile: :beers: 
