### PR TITLE
Fixes bug in SqlTimingParameter.GetHashCode

### DIFF
--- a/StackExchange.Profiling.Tests/SqlTimingParameterTest.cs
+++ b/StackExchange.Profiling.Tests/SqlTimingParameterTest.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StackExchange.Profiling.Tests
+{
+    [TestFixture]
+    public class SqlTimingParameterTest : BaseTest
+    {
+        [Test]
+        public void GetHashCodeWithNullParameterValue()
+        {
+            SqlTimingParameter parameter = new SqlTimingParameter();
+            parameter.Name = "TestParameter";
+            parameter.Value = null;
+            parameter.ParentSqlTimingId = Guid.NewGuid();
+
+            Assert.DoesNotThrow(() => parameter.GetHashCode());
+        }
+    }
+}

--- a/StackExchange.Profiling.Tests/StackExchange.Profiling.Tests.csproj
+++ b/StackExchange.Profiling.Tests/StackExchange.Profiling.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="lib\HaackHttpSimulator\SimulatedHttpRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MiniProfilerTest.cs" />
+    <Compile Include="SqlTimingParameterTest.cs" />
     <Compile Include="Storage\SqlCeStorage.cs" />
     <Compile Include="Storage\SqlServerStorageTest.cs" />
     <Compile Include="Storage\TestHttpRuntimeCacheStorage.cs" />

--- a/StackExchange.Profiling/SqlTimingParameter.cs
+++ b/StackExchange.Profiling/SqlTimingParameter.cs
@@ -57,7 +57,12 @@ namespace StackExchange.Profiling
         /// </summary>
         public override int GetHashCode()
         {
-            return ParentSqlTimingId.GetHashCode() ^ Name.GetHashCode() ^ Value.GetHashCode();
+            int hashcode = ParentSqlTimingId.GetHashCode() ^ Name.GetHashCode();
+            
+            if (Value != null)
+                hashcode ^= Value.GetHashCode();
+
+            return hashcode;
         }
 
         /// <summary>


### PR DESCRIPTION
Calling SqlTimingParameter's GetHashCode implementation when Value is
null throws a NullReferenceException.

This corrects that and adds a passing test to assert the behavior.
