### PR TITLE
(ruby) unescaping isn't needed for xml, fixes 'invalid %-encoding'

### DIFF
--- a/Ruby/lib/patches/sql_patches.rb
+++ b/Ruby/lib/patches/sql_patches.rb
@@ -200,7 +200,12 @@ if SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0" #  
 
       data = "#{request_context[:method].upcase} #{request_context[:uri]}"
       if request_context[:method] == :post and request_context[:data]
-        data << "\n#{Rack::Utils.unescape(request_context[:data])}"
+        if request_context[:headers].include("Content-Type") and request_context[:headers]["Content-Type"] == "text/xml"
+          # it's xml, unescaping isn't needed
+          data << "\n#{request_context[:data]}"
+        else
+          data << "\n#{Rack::Utils.unescape(request_context[:data])}"
+        end
       end
       result.instance_variable_set("@miniprofiler_sql_id", ::Rack::MiniProfiler.record_sql(data, elapsed_time))
 


### PR DESCRIPTION
if we try to unescape an XML request that contains % (percent sign) it
makes Rack::Utils.unescape angry because it can't unescape single %.
also it's XML, decoding it like urlencoded request body is wrong.

this is the error I got which will be fixed by this patch:

```
invalid %-encoding (<?xml version="1.0" encoding="UTF-8"?><add><doc><field name="id">Business 2</field><field name="type">Business</field><field name="type">ActiveRecord::Base</field><field name="class_name">Business</field><field name="name_sort_s">آی کار خواه دکرد؟</field><field name="user_id_i">1</field><field name="city_id_i">1</field><field name="suburb_id_i">1</field><field name="status_i">0</field><field name="rating_i">0</field><field name="rating_count_i">0</field><field name="categories_id_im">1</field><field name="options_im">13</field><field name="options_im">20</field><field name="options_im">10</field><field name="options_im">18</field><field name="tarin_score_i">0</field><field boost="10" name="name_text">آی کار خواه دکرد؟</field><field boost="5" name="categories_text">foo-cat</field><field boost="5" name="categories_text">foo-sub-cat</field><field boost="5" name="categories_text">foo-sub-sub-cat</field><field boost="2" name="description_text">ding
doong

foo
bar
baz

&lt;br&gt;

%
</field><field name="address_text"></field><field name="phone_text"></field><field name="city_text">تهران</field><field name="suburb_text">مهرآباد</field></doc></add>)
```
