### PR TITLE
Fixes infinite recursion issue when re-using  XmlHttpRequest objects.

### DIFF
--- a/StackExchange.Profiling/UI/includes.js
+++ b/StackExchange.Profiling/UI/includes.js
@@ -534,20 +534,23 @@ var MiniProfiler = (function () {
           var _send = XMLHttpRequest.prototype.send;
 
           XMLHttpRequest.prototype.send = function sendReplacement(data) {
-            this._onreadystatechange = this.onreadystatechange;
-
-            this.onreadystatechange = function onReadyStateChangeReplacement() {
-              if (this.readyState == 4) {
-                var stringIds = this.getResponseHeader('X-MiniProfiler-Ids');
-                if (stringIds) {
-                  var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
-                  fetchResults(ids);
+            if (typeof (this.miniprofiler) == 'undefined' || typeof (this.miniprofiler.old_onreadystatechange) == 'undefined') {
+              this.miniprofiler = { old_onreadystatechange: this.onreadystatechange };
+  
+              this.onreadystatechange = function onReadyStateChangeReplacement() {
+                if (this.readyState == 4) {
+                  var stringIds = this.getResponseHeader('X-MiniProfiler-Ids');
+                  if (stringIds) {
+                    var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
+                    fetchResults(ids);
+                  }
                 }
-              }
-
-              return this._onreadystatechange.apply(this, arguments);
-            };
-
+  
+                if (this.miniprofiler.old_onreadystatechange != null)
+                  return this.miniprofiler.old_onreadystatechange.apply(this, arguments);
+              };
+            }
+            
             return _send.apply(this, arguments);
           };
         }


### PR DESCRIPTION
I ran into a strange situation where I was getting stack overflow and out of memory errors from JavaScript when having both MiniProfiler and Angular included in my project.  The cause seems to be a re-use of XmlHttpRequest somewhere in either my code, or another third party library.  The original AngularJS logic in StackExchange.Profiling\UI\includes.js didn't have conditional checks to ensure the onreadystatechange override didn't get added multiple times, so when "send" would get called a second time, it would overwrite this._onreadystatechange with the old method.  Since that variable would be considered a pointer reference, the overridden onreadystatechange would recursively call itself.

The changes added below detects if the onreadystatechange event has already been overridden by MiniProfiler, and if not, executes the existing logic.  Also, I changed the location of this._onreadystatechange to this.miniprofiler.old_onreadystatechange, since there's a good possibility another script could be using the"_onreadystatechange" variable name, and we don't want MiniProfiler introducing inconsistencies in third party libraries (and vice versa.)
